### PR TITLE
*: bump up "tokio" to 1.18.0

### DIFF
--- a/avalanche-api/Cargo.toml
+++ b/avalanche-api/Cargo.toml
@@ -10,7 +10,7 @@ aws-smithy-types = "0.40.2"
 chrono = "0.4.19"
 log = "0.4.16"
 serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.18.0", features = ["full"] }
 utils = { path = "../utils" }
 
 [dev-dependencies]

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -18,5 +18,5 @@ clap = { version = "3.1.12", features = ["cargo", "derive"] }
 env_logger = "0.9.0"
 log = "0.4.16"
 tempfile = "3.3.0"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.18.0", features = ["full"] }
 utils = { path = "../utils" }

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.79"
 serde_yaml = "0.8.23"
 signal-hook = "0.3.13"
 subnet-evm = { path = "../subnet-evm" }
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.18.0", features = ["full"] }
 utils = { path = "../utils" }
 
 [dev-dependencies]

--- a/aws/Cargo.toml
+++ b/aws/Cargo.toml
@@ -24,7 +24,7 @@ ring = "0.16.20"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.18.0", features = ["full"] }
 tokio-stream = "0.1.8"
 utils = { path = "../utils" }
 

--- a/dev-machine-aws/Cargo.toml
+++ b/dev-machine-aws/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.16"
 rust-embed = "6.4.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.8.23"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.18.0", features = ["full"] }
 utils = { path = "../utils" }
 
 [dev-dependencies]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,7 +20,7 @@ ring = "0.16.20"
 ripemd = "0.1.1"
 serde = { version = "1.0.136", features = ["derive"] }
 tar = "0.4.38"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.18.0", features = ["full"] }
 url = "2.2.2"
 walkdir = "2.3.2"
 whoami = "1.2.1"


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuho.lee@avalabs.org>