### PR TITLE
avalanche-types: add Copy macro to Id

### DIFF
--- a/avalanche-types/src/ids.rs
+++ b/avalanche-types/src/ids.rs
@@ -31,7 +31,7 @@ lazy_static! {
 
 /// ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/ids#ID
 /// ref. https://docs.rs/zerocopy/latest/zerocopy/trait.AsBytes.html#safety
-#[derive(Debug, Deserialize, Clone, Eq, AsBytes, FromBytes, Unaligned)]
+#[derive(Debug, Deserialize, Clone, Copy, Eq, AsBytes, FromBytes, Unaligned)]
 #[repr(transparent)]
 pub struct Id([u8; ID_LEN]);
 


### PR DESCRIPTION
Adding Copy macro unlocks `clone()` which is very useful in certain circumstances.


Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>