### PR TITLE
add --avalanchego-release-tag 

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-kms"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-ops"
-version = "0.3.8-beta.2" # https://crates.io/crates/avalanche-ops
+version = "0.3.8-beta.3" # https://crates.io/crates/avalanche-ops
 edition = "2021"
 rust-version = "1.68"
 publish = true

--- a/avalanche-ops/src/aws/cfn-templates/asg_ubuntu.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/asg_ubuntu.yaml
@@ -77,6 +77,11 @@ Parameters:
     Default: "unknown"
     Description: The name of the OS distribution and kind. Used for Rust binary download links.
 
+  AvalancheGoReleaseTag:
+    Type: String
+    Default: "latest"
+    Description: The release tag name in https://github.com/ava-labs/avalanchego/releases. This is ignored if the binary is found in the S3 bucket.
+
   # use https://github.com/gyuho/aws-manager/blob/main/src/ec2/mod.rs for better defaults
   InstanceTypes:
     Type: CommaDelimitedList
@@ -639,6 +644,7 @@ Resources:
               --s3-bucket ${S3BucketName} \
               --avalanchego-s3-key ${Id}/bootstrap/install/avalanchego \
               --avalanchego-local-path /usr/local/bin/avalanchego \
+              --avalanchego-release-tag ${AvalancheGoReleaseTag} \
               --rust-os-type ${RustOsType} \
               --aws-volume-provisioner-s3-key ${Id}/bootstrap/install/aws-volume-provisioner \
               --aws-volume-provisioner-local-path /usr/local/bin/aws-volume-provisioner \

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -46,6 +46,10 @@ pub struct Spec {
     /// Upload artifacts from the local machine to share with remote machines.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upload_artifacts: Option<UploadArtifacts>,
+    /// Non-empty to specify avalanchego release tag to download.
+    /// Discarded if avalanchego binary was uploaded to S3.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avalanchego_release_tag: Option<String>,
 
     /// Flag to pass to the "avalanched" command-line interface.
     pub avalanched_config: crate::aws::avalanched::Flags,
@@ -322,6 +326,8 @@ pub struct DefaultSpecOption {
     pub upload_artifacts_avalanched_aws_local_bin: String,
     pub upload_artifacts_avalanchego_local_bin: String,
     pub upload_artifacts_prometheus_metrics_rules_file_path: String,
+
+    pub avalanchego_release_tag: String,
 
     pub avalanched_log_level: String,
     pub avalanched_use_default_config: bool,
@@ -623,6 +629,12 @@ impl Spec {
             Some(upload_artifacts)
         };
 
+        let avalanchego_release_tag = if opts.avalanchego_release_tag.is_empty() {
+            None
+        } else {
+            Some(opts.avalanchego_release_tag.clone())
+        };
+
         let mut coreth_chain_config = coreth_chain_config::Config::default();
         if opts.coreth_continuous_profiler_enabled {
             coreth_chain_config.continuous_profiler_dir =
@@ -702,6 +714,7 @@ impl Spec {
                 resources,
                 machine,
                 upload_artifacts,
+                avalanchego_release_tag,
 
                 avalanched_config,
 
@@ -1009,6 +1022,7 @@ upload_artifacts:
   avalanched_local_bin: {avalanched_bin}
   avalanche_config_local_bin: {avalanche_config_bin}
   avalanchego_local_bin: {avalanchego_bin}
+avalanchego_release_tag: latest
 
 avalanched_config:
   log_level: info
@@ -1136,6 +1150,7 @@ coreth_chain_config:
 
             prometheus_metrics_rules_file_path: String::new(),
         }),
+        avalanchego_release_tag: Some(String::from("latest")),
 
         avalanched_config: crate::aws::avalanched::Flags {
             log_level: String::from("info"),

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanched-aws"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/avalanched-aws/src/install_artifacts/mod.rs
+++ b/avalanched-aws/src/install_artifacts/mod.rs
@@ -43,7 +43,7 @@ pub fn command() -> Command {
         .arg(
             Arg::new("AVALANCHEGO_S3_KEY")
                 .long("avalanchego-s3-key")
-                .help("Non-empty to download from S3")
+                .help("Non-empty to download from S3 (overwrites --avalanchego-release-tag)")
                 .required(false)
                 .num_args(1),
         )
@@ -51,6 +51,13 @@ pub fn command() -> Command {
             Arg::new("AVALANCHEGO_LOCAL_PATH")
                 .long("avalanchego-local-path")
                 .help("Non-empty to download avalanchego")
+                .required(false)
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("AVALANCHEGO_RELEASE_TAG")
+                .long("avalanchego-release-tag")
+                .help("Non-empty to specify avalanchego release tag to download (ignored if --avalanchego-s3-key is not empty)")
                 .required(false)
                 .num_args(1),
         )
@@ -116,6 +123,7 @@ pub async fn execute(
     s3_bucket: &str,
     avalanchego_s3_key: &str,
     avalanchego_local_path: &str,
+    avalanchego_release_tag: Option<String>,
     rust_os_type: &str,
     aws_volume_provisioner_s3_key: &str,
     aws_volume_provisioner_local_path: &str,
@@ -188,7 +196,9 @@ pub async fn execute(
     };
     if need_github_download {
         log::info!("downloading avalanchego from github");
-        let tmp_path = avalanche_installer::avalanchego::github::download(None, None, None).await?;
+        let tmp_path =
+            avalanche_installer::avalanchego::github::download(None, None, avalanchego_release_tag)
+                .await?;
         fs::copy(&tmp_path, &avalanchego_local_path)?;
         fs::remove_file(&tmp_path)?;
     }

--- a/avalanched-aws/src/main.rs
+++ b/avalanched-aws/src/main.rs
@@ -36,6 +36,12 @@ async fn main() {
         }
 
         Some((install_artifacts::NAME, sub_matches)) => {
+            let v = sub_matches
+                .get_one::<String>("AVALANCHEGO_RELEASE_TAG")
+                .unwrap_or(&String::new())
+                .clone();
+            let avalanchego_release_tag = if v.is_empty() { None } else { Some(v.clone()) };
+
             install_artifacts::execute(
                 &sub_matches
                     .get_one::<String>("LOG_LEVEL")
@@ -53,6 +59,7 @@ async fn main() {
                 &sub_matches
                     .get_one::<String>("AVALANCHEGO_LOCAL_PATH")
                     .unwrap_or(&String::new()),
+                avalanchego_release_tag,
                 &sub_matches
                     .get_one::<String>("RUST_OS_TYPE")
                     .unwrap_or(&String::from("ubuntu20.04")),

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalancheup-aws"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -702,6 +702,13 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
         build_param("VolumeProvisionerInitialWaitRandomSeconds", "10"),
     ]);
 
+    if let Some(avalanchego_release_tag) = &spec.avalanchego_release_tag {
+        common_asg_params.push(build_param(
+            "AvalancheGoReleaseTag",
+            &avalanchego_release_tag.clone(),
+        ));
+    }
+
     if !spec.machine.instance_types.is_empty() {
         let instance_types = spec.machine.instance_types.clone();
         common_asg_params.push(build_param("InstanceTypes", &instance_types.join(",")));

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -206,6 +206,13 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
+            Arg::new("AVALANCHEGO_RELEASE_TAG")
+                .long("avalanchego-release-tag")
+                .help("Non-empty to specify avalanchego release tag to download (ignored if --upload-artifacts-avalanchego-local-bin is not empty)")
+                .required(false)
+                .num_args(1),
+        )
+        .arg(
             Arg::new("NETWORK_NAME") 
                 .long("network-name")
                 .help("Sets the type of network by name (e.g., mainnet, fuji, custom)")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -168,6 +168,11 @@ async fn main() -> io::Result<()> {
                     .unwrap_or(&String::new())
                     .to_string(),
 
+                avalanchego_release_tag: sub_matches
+                    .get_one::<String>("AVALANCHEGO_RELEASE_TAG")
+                    .unwrap_or(&String::new())
+                    .clone(),
+
                 avalanched_log_level: sub_matches
                     .get_one::<String>("AVALANCHED_LOG_LEVEL")
                     .unwrap_or(&String::from("info"))

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzard-aws"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzardup-aws"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking-key-cert-s3-downloader"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking-signer-key-s3-downloader"
-version = "0.3.8-beta.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.3" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 


### PR DESCRIPTION
```
Usage: avalancheup-aws default-spec [OPTIONS] --arch-type <ARCH_TYPE> --rust-os-type <RUST_OS_TYPE>

Options:
  -l, --log-level <LOG_LEVEL>                                                                                                  Sets the log level [default: info] [possible values: debug, info]
      --arch-type <ARCH_TYPE>                                                                                                  Sets the machine architecture [default: amd64] [possible values: amd64, arm64]
      --rust-os-type <RUST_OS_TYPE>                                                                                            Sets Rust OS type [default: ubuntu20.04] [possible values: ubuntu20.04]
      --anchor-nodes <ANCHOR_NODES>                                                                                            Sets the number of anchor nodes (only used when non-zero value) [default: 0]
      --non-anchor-nodes <NON_ANCHOR_NODES>                                                                                    Sets the number of non-anchor nodes (only used when non-zero value) [default: 0]
      --key-files-dir <KEY_FILES_DIR>                                                                                          Directory to write key files to
      --keys-to-generate <KEYS_TO_GENERATE>                                                                                    Sets the number of keys to generate (only requires for custom network, default if not specified) [default: 0]
  -r, --region <REGION>                                                                                                        Sets the AWS region for API calls/endpoints [default: us-west-2]
      --ingress-ipv4-cidr <INGRESS_IPV4_CIDR>                                                                                  Sets the IPv4 CIDR range for ingress traffic HTTP/SSH (leave empty to default to public IP on the local host)
      --instance-mode <INSTANCE_MODE>                                                                                          Sets instance mode [default: spot] [possible values: spot, on-demand]
      --instance-size <INSTANCE_SIZE>                                                                                          Sets instance size [default: xlarge] [possible values: large, xlarge, 2xlarge, 4xlarge, 8xlarge]
      --instance-types <INSTANCE_TYPES>                                                                                        Sets the comma-separated instance types (overwrites --instance-size)
      --ip-mode <IP_MODE>                                                                                                      Sets IP mode to provision EC2 elastic IPs for all nodes [default: elastic] [possible values: elastic, ephemeral]
      --enable-nlb                                                                                                             Sets to enable NLB
      --disable-logs-auto-removal                                                                                              Sets to disable CloudWatch logs auto removal
      --metrics-fetch-interval-seconds <METRICS_FETCH_INTERVAL_SECONDS>                                                        Sets the avalanche-telemetry-cloudwatch fetch interval and other system metrics push interval in seconds (0 to disable by default) [default: 0]
  -a, --aad-tag <AAD_TAG>                                                                                                      Sets the AAD tag for envelope encryption with KMS [default: avalanche-ops-aad-tag]
      --nlb-acm-certificate-arn <NLB_ACM_CERTIFICATE_ARN>                                                                      Sets ACM ARN to enable NLB HTTPS
      --upload-artifacts-aws-volume-provisioner-local-bin <UPLOAD_ARTIFACTS_AWS_VOLUME_PROVISIONER_LOCAL_BIN>                  Sets the aws-volume-provisioner binary path in the local machine to be shared with remote machines (if empty, it downloads the latest from github)
      --upload-artifacts-aws-ip-provisioner-local-bin <UPLOAD_ARTIFACTS_AWS_IP_PROVISIONER_LOCAL_BIN>                          Sets the aws-ip-provisioner binary path in the local machine to be shared with remote machines (if empty, it downloads the latest from github)
      --upload-artifacts-avalanche-telemetry-cloudwatch-local-bin <UPLOAD_ARTIFACTS_AVALANCHE_TELEMETRY_CLOUDWATCH_LOCAL_BIN>  Sets the avalanche-telemetry-cloudwatch binary path in the local machine to be shared with remote machines (if empty, it downloads the latest from github)
      --upload-artifacts-avalanched-aws-local-bin <UPLOAD_ARTIFACTS_AVALANCHED_AWS_LOCAL_BIN>                                  Sets the avalanched binary path in the local machine to be shared with remote machines (if empty, it downloads the latest from github)
      --upload-artifacts-avalanchego-local-bin <UPLOAD_ARTIFACTS_AVALANCHEGO_LOCAL_BIN>                                        Sets the AvalancheGo node binary path in the local machine to be shared with remote machines (if empty, it downloads the latest from github)
      --upload-artifacts-prometheus-metrics-rules-file-path <UPLOAD_ARTIFACTS_PROMETHEUS_METRICS_RULES_FILE_PATH>              Sets prometheus rules file path in the local machine to be shared with remote machines
      --avalanchego-release-tag <AVALANCHEGO_RELEASE_TAG>                                                                      Non-empty to specify avalanchego release tag to download (ignored if --upload-artifacts-avalanchego-local-bin is not empty)
```