### PR TITLE
Rename CMK to KMS key, add "avalanche-kms --grantee-principal"

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "avalanche-kms"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 
 [dependencies]
-avalanche-types = { version = "0.0.335", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.1", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.26.1"

--- a/avalanche-kms/README.md
+++ b/avalanche-kms/README.md
@@ -10,7 +10,7 @@
 ./target/release/avalanche-kms info --help
 ```
 
-To create a new KMS CMK:
+To create a new KMS key:
 
 ```bash
 ./target/release/avalanche-kms create \
@@ -18,7 +18,7 @@ To create a new KMS CMK:
 ```
 
 ```yaml
-# loaded CMK
+# loaded key
 
 id: arn:aws:kms:us-west-2:931867039610:key/9ca6d1a5-bc21-4326-8562-ad106f36a439
 key_type: aws-kms
@@ -36,7 +36,7 @@ h160_address: 0x75e3dc1926ca033ee06b0c378b0079241921e2aa
 To get the key information:
 
 ```bash
-# new CMK is successfully created
+# new KMS key is successfully created
 ./target/release/avalanche-kms info \
 --region=us-west-2 \
 --network-id=1 \
@@ -54,7 +54,7 @@ To get the key information:
 ```
 
 ```yaml
-# loaded CMK
+# loaded KMS key
 
 id: arn:aws:kms:us-west-2:931867039610:key/9ca6d1a5-bc21-4326-8562-ad106f36a439
 key_type: aws-kms

--- a/avalanche-kms/src/create/mod.rs
+++ b/avalanche-kms/src/create/mod.rs
@@ -125,7 +125,7 @@ pub async fn execute(
     );
 
     log::info!(
-        "requesting to create new {keys} KMS keys(s) with prefix '{key_name_prefix}' (in the {region}, grantee principal {grantee_principal})"
+        "requesting to create new {keys} KMS key(s) with prefix '{key_name_prefix}' (in the {region}, grantee principal {grantee_principal})"
     );
 
     let shared_config =

--- a/avalanche-kms/src/create/mod.rs
+++ b/avalanche-kms/src/create/mod.rs
@@ -22,7 +22,7 @@ pub const NAME: &str = "create";
 
 pub fn command() -> Command {
     Command::new(NAME)
-        .about("Creates an AWS KMS CMK")
+        .about("Create and fund AWS KMS keys")
         .arg(
             Arg::new("LOG_LEVEL")
                 .long("log-level")
@@ -45,7 +45,7 @@ pub fn command() -> Command {
         .arg(
             Arg::new("KEY_NAME_PREFIX")
                 .long("key-name-prefix")
-                .help("KMS CMK name prefix")
+                .help("KMS key name prefix")
                 .required(false)
                 .num_args(1),
         )
@@ -58,6 +58,8 @@ pub fn command() -> Command {
                 .value_parser(value_parser!(usize))
                 .default_value("1"),
         )
+
+        // optional to fund keys
         .arg(
             Arg::new("EVM_CHAIN_RPC_URL")
                 .long("evm-chain-rpc-url")
@@ -86,6 +88,7 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(1),
         )
+
         .arg(
             Arg::new("SKIP_PROMPT")
                 .long("skip-prompt")
@@ -112,7 +115,7 @@ pub async fn execute(
     );
 
     log::info!(
-        "requesting to create new {keys} KMS CMK(s) with prefix '{key_name_prefix}' (in the {region})"
+        "requesting to create new {keys} KMS keys(s) with prefix '{key_name_prefix}' (in the {region})"
     );
 
     let shared_config =
@@ -129,10 +132,10 @@ pub async fn execute(
     if !skip_prompt {
         let options = &[
             format!(
-                "No, I am not ready to create new {keys} KMS CMK(s) with '{key_name_prefix}' in '{region}'."
+                "No, I am not ready to create new {keys} KMS key(s) with '{key_name_prefix}' in '{region}'."
             ),
             format!(
-                "Yes, let's create new {keys} KMS CMK(s) with '{key_name_prefix}' in '{region}'."
+                "Yes, let's create new {keys} KMS key(s) with '{key_name_prefix}' in '{region}'."
             ),
         ];
         let selected = Select::with_theme(&ColorfulTheme::default())
@@ -152,11 +155,11 @@ pub async fn execute(
         stdout(),
         SetForegroundColor(Color::Green),
         Print(format!(
-            "\nCreating new KMS CMKs with '{key_name_prefix}' in region {region}\n",
+            "\nCreating new KMS keys with '{key_name_prefix}' in region {region}\n",
         )),
         ResetColor
     )?;
-    let mut cmks = Vec::new();
+    let mut kms_keys = Vec::new();
     for i in 0..keys {
         // to prevent rate limit errors
         // e.g.,
@@ -164,21 +167,21 @@ pub async fn execute(
         sleep(Duration::from_secs(2)).await;
 
         println!("");
-        log::info!("[{i}] creating CMk");
+        log::info!("[{i}] creating KMS key");
         let mut tags = HashMap::new();
         tags.insert(
             String::from("Name"),
             format!("{key_name_prefix}-{:03}", i + 1),
         );
-        let cmk = key::secp256k1::kms::aws::Cmk::create(kms_manager.clone(), tags)
+        let key = key::secp256k1::kms::aws::Key::create(kms_manager.clone(), tags)
             .await
             .unwrap();
 
-        let cmk_info = cmk.to_info(1).unwrap();
-        cmks.push(cmk_info.clone());
+        let key_info = key.to_info(1).unwrap();
+        kms_keys.push(key_info.clone());
 
         println!();
-        println!("loaded CMK\n\n{}\n", cmk_info);
+        println!("loaded KMS key\n\n{}\n", key_info);
         println!();
 
         if evm_funding_hotkey.is_empty() {
@@ -200,7 +203,7 @@ pub async fn execute(
         let funding_key_info = funding_key.to_info(network_id).unwrap();
         log::info!("loaded funding key: {}", funding_key_info.eth_address);
 
-        let transferee_addr = cmk_info.h160_address;
+        let transferee_addr = key_info.h160_address;
         execute!(
             stdout(),
             SetForegroundColor(Color::Green),
@@ -247,20 +250,20 @@ pub async fn execute(
         log::info!("evm ethers wallet SUCCESS with transaction id {}", tx_id);
     }
 
-    for cmk in cmks.iter() {
-        println!("{},{}", cmk.id.clone().unwrap(), cmk.eth_address)
+    for k in kms_keys.iter() {
+        println!("{},{}", k.id.clone().unwrap(), k.eth_address)
     }
 
     let exec_path = env::current_exe().expect("unexpected None current_exe");
     println!("\n# [UNSAFE] to delete the keys");
-    for cmk in cmks.iter() {
-        println!("{} delete --region={region} --pending-windows-in-days 7 --unsafe-skip-prompt --key-arn {}", exec_path.display(), cmk.id.clone().unwrap());
+    for k in kms_keys.iter() {
+        println!("{} delete --region={region} --pending-windows-in-days 7 --unsafe-skip-prompt --key-arn {}", exec_path.display(), k.id.clone().unwrap());
     }
 
     println!("\n# [UNSAFE] to fund the keys");
     let mut addresses = Vec::new();
-    for cmk in cmks.iter() {
-        addresses.push(cmk.eth_address.clone());
+    for k in kms_keys.iter() {
+        addresses.push(k.eth_address.clone());
     }
     println!("{} evm-transfer-from-hotkey --chain-rpc-url={evm_chain_rpc_url} --transferer-key=[FUNDING_HOTKEY] --transfer-amount-in-avax \"30000000\" --transferee-addresses {}", exec_path.display(), addresses.join(","));
 

--- a/avalanche-kms/src/delete/mod.rs
+++ b/avalanche-kms/src/delete/mod.rs
@@ -14,7 +14,7 @@ pub const NAME: &str = "delete";
 
 pub fn command() -> Command {
     Command::new(NAME)
-        .about("Deletes an AWS KMS CMK")
+        .about("Deletes an AWS KMS key")
         .arg(
             Arg::new("LOG_LEVEL")
                 .long("log-level")
@@ -38,7 +38,7 @@ pub fn command() -> Command {
             Arg::new("KEY_ARN")
                 .long("key-arn")
                 .short('a')
-                .help("KMS CMK ARN")
+                .help("KMS key ARN")
                 .required(true)
                 .num_args(1),
         )
@@ -89,28 +89,28 @@ pub async fn execute(
         stdout(),
         SetForegroundColor(Color::Red),
         Print(format!(
-            "\nLoading the KMS CMK {} in region {} for deletion\n",
+            "\nLoading the KMS key {} in region {} for deletion\n",
             key_arn, region
         )),
         ResetColor
     )?;
-    let cmk = key::secp256k1::kms::aws::Cmk::from_arn(kms_manager.clone(), key_arn)
+    let key = key::secp256k1::kms::aws::Key::from_arn(kms_manager.clone(), key_arn)
         .await
         .unwrap();
-    let cmk_info = cmk.to_info(1).unwrap();
+    let key_info = key.to_info(1).unwrap();
 
     println!();
-    println!("loaded CMK\n\n{}\n(mainnet)\n", cmk_info);
+    println!("loaded KMS key\n\n{}\n(mainnet)\n", key_info);
     println!();
 
     if !unsafe_skip_prompt {
         let options = &[
             format!(
-                "No, I am not ready to delete a new KMS CMK '{}' '{}' in {} days",
+                "No, I am not ready to delete a new KMS key '{}' '{}' in {} days",
                 region, key_arn, pending_windows_in_days
             ),
             format!(
-                "Yes, let's delete a new KMS CMK '{}' '{}' in {} days",
+                "Yes, let's delete a new KMS key '{}' '{}' in {} days",
                 region, key_arn, pending_windows_in_days
             ),
         ];
@@ -125,10 +125,10 @@ pub async fn execute(
         }
     }
 
-    cmk.delete(pending_windows_in_days).await.unwrap();
+    key.delete(pending_windows_in_days).await.unwrap();
 
     println!();
-    log::info!("successfully scheduled to delete CMK signer");
+    log::info!("successfully scheduled to delete KMS key signer");
 
     Ok(())
 }

--- a/avalanche-kms/src/main.rs
+++ b/avalanche-kms/src/main.rs
@@ -61,6 +61,11 @@ async fn main() -> io::Result<()> {
             };
             let keys = sub_matches.get_one::<usize>("KEYS").unwrap_or(&0).clone();
 
+            let grantee_principal = sub_matches
+                .get_one::<String>("GRANTEE_PRINCIPAL")
+                .unwrap_or(&String::new())
+                .clone();
+
             let evm_chain_rpc_url = sub_matches
                 .get_one::<String>("EVM_CHAIN_RPC_URL")
                 .unwrap_or(&String::new())
@@ -106,6 +111,7 @@ async fn main() -> io::Result<()> {
                 &sub_matches.get_one::<String>("REGION").unwrap().clone(),
                 &key_name_prefix,
                 keys,
+                &grantee_principal,
                 &evm_chain_rpc_url,
                 &evm_funding_hotkey,
                 evm_funding_amount_navax,

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-ops"
-version = "0.3.8-beta.4" # https://crates.io/crates/avalanche-ops
+version = "0.3.8-beta.5" # https://crates.io/crates/avalanche-ops
 edition = "2021"
 rust-version = "1.68"
 publish = true
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-avalanche-types = { version = "0.0.335", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.7"
 dir-manager = "0.0.1"

--- a/avalanche-ops/src/aws/cfn-templates/asg_ubuntu.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/asg_ubuntu.yaml
@@ -20,9 +20,9 @@ Parameters:
     AllowedValues: ["anchor", "non-anchor"]
     Description: Node kind.
 
-  KmsCmkArn:
+  KmsKeyArn:
     Type: String
-    Description: KMS CMK ARN that de/encrypts resources.
+    Description: KMS key ARN that de/encrypts resources.
 
   AadTag:
     Type: String
@@ -810,8 +810,8 @@ Resources:
         - Key: NODE_KIND
           Value: !Ref NodeKind
           PropagateAtLaunch: true
-        - Key: KMS_CMK_ARN
-          Value: !Ref KmsCmkArn
+        - Key: KMS_KEY_ARN
+          Value: !Ref KmsKeyArn
           PropagateAtLaunch: true
         - Key: AAD_TAG
           Value: !Ref AadTag

--- a/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
@@ -10,9 +10,9 @@ Parameters:
     Type: String
     Description: Unique identifier, prefix for all resources created below.
 
-  KmsCmkArn:
+  KmsKeyArn:
     Type: String
-    Description: KMS CMK ARN that de/encrypts resources.
+    Description: KMS key ARN that de/encrypts resources.
 
   S3BucketName:
     Type: String
@@ -82,8 +82,8 @@ Resources:
                 Action:
                   - kms:Encrypt # to generate TLS key and encrypt
                   - kms:GenerateDataKey* # to encrypt TLS key
-                  - kms:DescribeKey # to describe the CMK
-                Resource: { Ref: KmsCmkArn }
+                  - kms:DescribeKey # to describe the KMS key
+                Resource: { Ref: KmsKeyArn }
               - Effect: Allow
                 Action:
                   - s3:List*

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -94,13 +94,13 @@ pub struct Spec {
     pub avalanchego_genesis_template: Option<avalanchego_genesis::Genesis>,
 }
 
-/// Represents the KMS CMK resource.
+/// Represents the KMS key resource.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
-pub struct KmsCmk {
-    /// CMK Id.
+pub struct KmsKey {
+    /// Key Id.
     pub id: String,
-    /// CMK Arn.
+    /// Key Arn.
     pub arn: String,
 }
 
@@ -134,13 +134,13 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nlb_acm_certificate_arn: Option<String>,
 
-    /// KMS CMK ID to encrypt resources.
+    /// KMS key ID to encrypt resources.
     /// Only used for encrypting node certs and EC2 keys.
     /// None if not created yet.
     /// READ ONLY -- DO NOT SET.
     /// TODO: support existing key and load the ARN based on region and account number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub kms_cmk_symmetric_default_encrypt_key: Option<KmsCmk>,
+    pub kms_symmetric_default_encrypt_key: Option<KmsKey>,
 
     /// EC2 key pair name for SSH access to EC2 instances.
     /// READ ONLY -- DO NOT SET.
@@ -255,7 +255,7 @@ impl Resources {
 
             nlb_acm_certificate_arn: None,
 
-            kms_cmk_symmetric_default_encrypt_key: None,
+            kms_symmetric_default_encrypt_key: None,
 
             ec2_key_name: String::new(),
             ec2_key_path: String::new(),

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanched-aws"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 
@@ -12,7 +12,7 @@ path = "src/main.rs"
 avalanche-installer = "0.0.58" # https://crates.io/crates/avalanche-installer
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.75" # https://crates.io/crates/avalanche-telemetry-cloudwatch
-avalanche-types = { version = "0.0.335", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.56" # https://crates.io/crates/aws-ip-provisioner-installer
 aws-manager = { version = "0.25.4", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalanched-aws/src/agent/mod.rs
+++ b/avalanched-aws/src/agent/mod.rs
@@ -122,7 +122,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         rust_os_type: String::new(),
         instance_mode: String::new(),
         node_kind: node::Kind::Unknown(String::new()),
-        kms_cmk_arn: String::new(),
+        kms_key_arn: String::new(),
         aad_tag: String::new(),
         s3_bucket: String::new(),
         cloudwatch_config_file_path: String::new(),
@@ -160,8 +160,8 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
                     node::Kind::NonAnchor
                 };
             }
-            "KMS_CMK_ARN" => {
-                fetched_tags.kms_cmk_arn = v.to_string();
+            "KMS_KEY_ARN" => {
+                fetched_tags.kms_key_arn = v.to_string();
             }
             "AAD_TAG" => {
                 fetched_tags.aad_tag = v.to_string();
@@ -199,7 +199,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     );
     assert!(!fetched_tags.arch_type.is_empty());
     assert!(!fetched_tags.rust_os_type.is_empty());
-    assert!(!fetched_tags.kms_cmk_arn.is_empty());
+    assert!(!fetched_tags.kms_key_arn.is_empty());
     assert!(!fetched_tags.aad_tag.is_empty());
     assert!(!fetched_tags.s3_bucket.is_empty());
     assert!(!fetched_tags.cloudwatch_config_file_path.is_empty());
@@ -443,7 +443,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     log::info!("STEP: setting up certificates...");
     let envelope_manager = envelope::Manager::new(
         &kms_manager,
-        fetched_tags.kms_cmk_arn.to_string(),
+        fetched_tags.kms_key_arn.to_string(),
         fetched_tags.aad_tag.to_string(),
     );
     let local_tls_key_path = avalanchego_config.staking_tls_key_file.clone().unwrap();
@@ -1108,7 +1108,7 @@ struct Tags {
     rust_os_type: String,
     instance_mode: String,
     node_kind: node::Kind,
-    kms_cmk_arn: String,
+    kms_key_arn: String,
     aad_tag: String,
     s3_bucket: String,
     cloudwatch_config_file_path: String,

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalancheup-aws"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-ops = { path = "../avalanche-ops" }
-avalanche-types = { version = "0.0.335", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -190,11 +190,7 @@ pub async fn execute(
 
     // delete this first since KMS key delete does not depend on ASG/VPC
     // (mainly to speed up delete operation)
-    if spec
-        .resources
-        .kms_cmk_symmetric_default_encrypt_key
-        .is_some()
-    {
+    if spec.resources.kms_symmetric_default_encrypt_key.is_some() {
         sleep(Duration::from_secs(1)).await;
 
         execute!(
@@ -204,10 +200,7 @@ pub async fn execute(
             ResetColor
         )?;
 
-        let k = spec
-            .resources
-            .kms_cmk_symmetric_default_encrypt_key
-            .unwrap();
+        let k = spec.resources.kms_symmetric_default_encrypt_key.unwrap();
         kms_manager
             .schedule_to_delete(k.id.as_str(), 7)
             .await

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzard-aws"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 
@@ -9,7 +9,7 @@ name = "blizzard-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.335", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzardup-aws"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 
@@ -9,7 +9,7 @@ name = "blizzardup-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.335", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/cdk/avalancheup-aws/README.md
+++ b/cdk/avalancheup-aws/README.md
@@ -51,15 +51,15 @@ aws s3 ls s3://${S3_BUCKET_NAME}/
 
 ### Step 3. Create KMS key for envelope-encrypting the node certificate
 
-*NOTE: Replace `KMS_CMK_ARN` with your own KMS key:*
+*NOTE: Replace `KMS_KEY_ARN` with your own KMS key:*
 
 ```bash
-KMS_CMK_ARN=$(aws kms --region us-west-2 create-key --query KeyMetadata.Arn --output text)
-echo ${KMS_CMK_ARN}
+KMS_KEY_ARN=$(aws kms --region us-west-2 create-key --query KeyMetadata.Arn --output text)
+echo ${KMS_KEY_ARN}
 
 # e.g.,
-KMS_CMK_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9
-aws kms describe-key --region us-west-2 --key-id ${KMS_CMK_ARN} --query KeyMetadata.Arn --output text
+KMS_KEY_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9
+aws kms describe-key --region us-west-2 --key-id ${KMS_KEY_ARN} --query KeyMetadata.Arn --output text
 
 # e.g.,
 # arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9
@@ -69,14 +69,14 @@ To delete the key later:
 
 ```bash
 # e.g.,
-KMS_CMK_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9
+KMS_KEY_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9
 
 # to delete
 aws kms schedule-key-deletion \
 --region us-west-2 \
---key-id ${KMS_CMK_ARN} \
+--key-id ${KMS_KEY_ARN} \
 --pending-window-in-days 7
-aws kms describe-key --key-id ${KMS_CMK_ARN}
+aws kms describe-key --key-id ${KMS_KEY_ARN}
 ```
 
 ### Step 4. Create EC2 key pair for SSH access to the nodes
@@ -112,7 +112,7 @@ cdk --version
 - `CDK_REGION`: AWS region to create resources
 - `CDK_ACCOUNT`: AWS account to create resources
 - `ID`: Unique identifier for the node
-- `KMS_CMK_ARN`: AWS CMK ARN for envelope-encryption of your node certificate
+- `KMS_KEY_ARN`: AWS KMS key ARN for envelope-encryption of your node certificate
 - `S3_BUCKET_NAME`: S3 bucket name to back up the node certificate
 
 For example:
@@ -123,7 +123,7 @@ cd ${HOME}/avalanche-ops/cdk/avalancheup-aws
 CDK_REGION=us-west-2 \
 CDK_ACCOUNT=931867039610 \
 ID=my-cluster-id \
-KMS_CMK_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9 \
+KMS_KEY_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9 \
 S3_BUCKET_NAME=avalancheup-aws-test-bucket-with-cdk \
 npx cdk deploy avalancheup-aws-instance-role-stack
 ```
@@ -177,7 +177,7 @@ See [`vpc.yaml`](../../avalanche-ops/src/aws/cfn-templates/vpc.yaml) for the Clo
 - `CDK_REGION`: AWS region to create resources
 - `CDK_ACCOUNT`: AWS account to create resources
 - `ID`: Unique identifier for the node
-- `KMS_CMK_ARN`: AWS CMK ARN for envelope-encryption of your node certificate
+- `KMS_KEY_ARN`: AWS KMS key ARN for envelope-encryption of your node certificate
 - `S3_BUCKET_NAME`: S3 bucket name to back up the node certificate
 - `EC2_KEY_PAIR_NAME`: EC2 key pair name for SSH access
 - `AAD_TAG`: Authentication of additional authenticated data (AAD) for envelope-encryption
@@ -196,7 +196,7 @@ PUBLIC_SUBNET_IDS='subnet-05cabd5919ddc9777,subnet-0e9cd3f506f6dab12,subnet-0c3c
 CDK_REGION=us-west-2 \
 CDK_ACCOUNT=931867039610 \
 ID=my-cluster-id \
-KMS_CMK_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9 \
+KMS_KEY_ARN=arn:aws:kms:us-west-2:931867039610:key/c5a7894a-ddd8-4b67-8c98-081d053bc4e9 \
 S3_BUCKET_NAME=avalancheup-aws-test-bucket-with-cdk \
 EC2_KEY_PAIR_NAME=avalancheup-aws-test-ec2-key-with-cdk \
 AAD_TAG=my-add-tag \
@@ -243,7 +243,7 @@ And go to S3 bucket to see the node certificate being published from the `avalan
 --s3-bucket=avalanche-ops-202207-3cq76s4cie \
 --s3-key-tls-key=aops-fuji-202207-23XhJA/pki/NodeID-KsGs96iZYWHS9bNwA47VKPmkNBVUKRFsD.key.zstd.encrypted \
 --s3-key-tls-cert=aops-fuji-202207-23XhJA/pki/NodeID-KsGs96iZYWHS9bNwA47VKPmkNBVUKRFsD.crt.zstd.encrypted \
---kms-cmk-id=87c771e3-6166-414b-b46e-5f4845e57a3c \
+--kms-key-id=87c771e3-6166-414b-b46e-5f4845e57a3c \
 --aad-tag='avalanche-ops-aad-tag' \
 --tls-key-path=/tmp/NodeID-KsGs96iZYWHS9bNwA47VKPmkNBVUKRFsD.key \
 --tls-cert-path=/tmp/NodeID-KsGs96iZYWHS9bNwA47VKPmkNBVUKRFsD.cr
@@ -253,7 +253,7 @@ And go to S3 bucket to see the node certificate being published from the `avalan
 --aws-region=us-west-2 \
 --s3-bucket=avalanche-ops-202207-3cq76s4cie \
 --s3-key=aops-fuji-202207-23XhJA/pki/staking-signer-keys/NodeID-KsGs96iZYWHS9bNwA47VKPmkNBVUKRFsD.staking-signer.bls.key.zstd.encrypted \
---kms-cmk-id=87c771e3-6166-414b-b46e-5f4845e57a3c \
+--kms-key-id=87c771e3-6166-414b-b46e-5f4845e57a3c \
 --aad-tag='avalanche-ops-aad-tag' \
 --key-path=/tmp/NodeID-KsGs96iZYWHS9bNwA47VKPmkNBVUKRFsD.bls.key \
 ```

--- a/cdk/avalancheup-aws/bin/avalancheup-aws.ts
+++ b/cdk/avalancheup-aws/bin/avalancheup-aws.ts
@@ -23,8 +23,8 @@ export class AvalancheupInstanceRoleStack extends cdk.Stack {
     const paramId: cdk.CfnParameter = tmplAsg.getParameter('Id');
     paramId.default = process.env.ID;
 
-    const paramKmsCmkArn: cdk.CfnParameter = tmplAsg.getParameter('KmsCmkArn');
-    paramKmsCmkArn.default = process.env.KMS_CMK_ARN;
+    const paramKmsKeyArn: cdk.CfnParameter = tmplAsg.getParameter('KmsKeyArn');
+    paramKmsKeyArn.default = process.env.KMS_KEY_ARN;
 
     const paramS3BucketName: cdk.CfnParameter = tmplAsg.getParameter('S3BucketName');
     paramS3BucketName.default = process.env.S3_BUCKET_NAME;
@@ -80,8 +80,8 @@ export class AvalancheupInstanceAsgStack extends cdk.Stack {
     const paramId: cdk.CfnParameter = tmplAsg.getParameter('Id');
     paramId.default = process.env.ID;
 
-    const paramKmsCmkArn: cdk.CfnParameter = tmplAsg.getParameter('KmsCmkArn');
-    paramKmsCmkArn.default = process.env.KMS_CMK_ARN;
+    const paramKmsKeyArn: cdk.CfnParameter = tmplAsg.getParameter('KmsKeyArn');
+    paramKmsKeyArn.default = process.env.KMS_KEY_ARN;
 
     const paramS3BucketName: cdk.CfnParameter = tmplAsg.getParameter('S3BucketName');
     paramS3BucketName.default = process.env.S3_BUCKET_NAME;

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "staking-key-cert-s3-downloader"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 
 [dependencies]
-avalanche-types = { version = "0.0.335", features = ["cert"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.337", features = ["cert"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.1", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"

--- a/staking-key-cert-s3-downloader/src/command.rs
+++ b/staking-key-cert-s3-downloader/src/command.rs
@@ -27,7 +27,7 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
 
     let envelope_manager = envelope::Manager::new(
         &kms_manager,
-        opts.kms_cmk_id.clone(),
+        opts.kms_key_id.clone(),
         // must've be equal for envelope encryption
         // e.g., "cfn-templates" tag "AAD_TAG"
         opts.aad_tag.clone(),

--- a/staking-key-cert-s3-downloader/src/flags.rs
+++ b/staking-key-cert-s3-downloader/src/flags.rs
@@ -6,7 +6,7 @@ pub struct Options {
     pub s3_bucket: String,
     pub s3_key_tls_key: String,
     pub s3_key_tls_cert: String,
-    pub kms_cmk_id: String,
+    pub kms_key_id: String,
     pub aad_tag: String,
     pub tls_key_path: String,
     pub tls_cert_path: String,

--- a/staking-key-cert-s3-downloader/src/main.rs
+++ b/staking-key-cert-s3-downloader/src/main.rs
@@ -21,7 +21,7 @@ staking-key-cert-s3-downloader \
 --s3-bucket=info \
 --s3-key-tls-key=pki/NodeABCDE.key.zstd.encrypted \
 --s3-key-tls-cert=pki/NodeABCDE.crt.zstd.encrypted \
---kms-cmk-id=abc-abc-abc \
+--kms-key-id=abc-abc-abc \
 --aad-tag=mytag \
 --tls-key-path=pki/NodeABCDE.key \
 --tls-cert-path=pki/NodeABCDE.crt
@@ -67,9 +67,9 @@ staking-key-cert-s3-downloader \
                 .num_args(1),
         )
         .arg(
-            Arg::new("KMS_CMK_ID")
-                .long("kms-cmk-id")
-                .help("Sets the KMS CMK Id to envelope-decrypt the files from S3")
+            Arg::new("KMS_KEY_ID")
+                .long("kms-key-id")
+                .help("Sets the KMS key Id to envelope-decrypt the files from S3")
                 .required(true)
                 .num_args(1),
         )
@@ -108,7 +108,7 @@ staking-key-cert-s3-downloader \
             .get_one::<String>("S3_KEY_TLS_CERT")
             .unwrap()
             .clone(),
-        kms_cmk_id: matches.get_one::<String>("KMS_CMK_ID").unwrap().clone(),
+        kms_key_id: matches.get_one::<String>("KMS_KEY_ID").unwrap().clone(),
         aad_tag: matches.get_one::<String>("AAD_TAG").unwrap().clone(),
         tls_key_path: matches.get_one::<String>("TLS_KEY_PATH").unwrap().clone(),
         tls_cert_path: matches.get_one::<String>("TLS_CERT_PATH").unwrap().clone(),

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking-signer-key-s3-downloader"
-version = "0.3.8-beta.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.3.8-beta.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.68"
 

--- a/staking-signer-key-s3-downloader/src/command.rs
+++ b/staking-signer-key-s3-downloader/src/command.rs
@@ -26,7 +26,7 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
 
     let envelope_manager = envelope::Manager::new(
         &kms_manager,
-        opts.kms_cmk_id.clone(),
+        opts.kms_key_id.clone(),
         // must've be equal for envelope encryption
         // e.g., "cfn-templates" tag "AAD_TAG"
         opts.aad_tag.clone(),

--- a/staking-signer-key-s3-downloader/src/flags.rs
+++ b/staking-signer-key-s3-downloader/src/flags.rs
@@ -5,7 +5,7 @@ pub struct Options {
     pub region: String,
     pub s3_bucket: String,
     pub s3_key: String,
-    pub kms_cmk_id: String,
+    pub kms_key_id: String,
     pub aad_tag: String,
     pub key_path: String,
 }

--- a/staking-signer-key-s3-downloader/src/main.rs
+++ b/staking-signer-key-s3-downloader/src/main.rs
@@ -20,7 +20,7 @@ staking-signer-key-s3-downloader \
 --aws-region=us-west-2 \
 --s3-bucket=info \
 --s3-key=pki/NodeABCDE.key.zstd.encrypted \
---kms-cmk-id=abc-abc-abc \
+--kms-key-id=abc-abc-abc \
 --aad-tag=mytag \
 --key-path=pki/NodeABCDE.key
 
@@ -58,9 +58,9 @@ staking-signer-key-s3-downloader \
                 .num_args(1),
         )
         .arg(
-            Arg::new("KMS_CMK_ID")
-                .long("kms-cmk-id")
-                .help("Sets the KMS CMK Id to envelope-decrypt the files from S3")
+            Arg::new("KMS_KEY_ID")
+                .long("kms-key-id")
+                .help("Sets the KMS key Id to envelope-decrypt the files from S3")
                 .required(true)
                 .num_args(1),
         )
@@ -88,7 +88,7 @@ staking-signer-key-s3-downloader \
         region: matches.get_one::<String>("REGION").unwrap().clone(),
         s3_bucket: matches.get_one::<String>("S3_BUCKET").unwrap().clone(),
         s3_key: matches.get_one::<String>("S3_KEY").unwrap().clone(),
-        kms_cmk_id: matches.get_one::<String>("KMS_CMK_ID").unwrap().clone(),
+        kms_key_id: matches.get_one::<String>("KMS_KEY_ID").unwrap().clone(),
         aad_tag: matches.get_one::<String>("AAD_TAG").unwrap().clone(),
         key_path: matches.get_one::<String>("KEY_PATH").unwrap().clone(),
     };


### PR DESCRIPTION
> AWS KMS has replaced the term customer master key (CMK) with AWS KMS key and KMS key. The concept has not changed. To prevent breaking changes, AWS KMS is keeping some variations of this term.

ref. https://docs.aws.amazon.com/kms/latest/APIReference/Welcome.html