### PR TITLE
*: bump up avalanche-types to support consensus-app-concurrency

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.68"
 
 [dependencies]
-avalanche-types = { version = "0.0.339", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.1", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.26.1"

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-avalanche-types = { version = "0.0.339", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.7"
 dir-manager = "0.0.1"

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -1074,6 +1074,8 @@ avalanchego_config:
   throttler-inbound-cpu-validator-alloc: 100000
   throttler-inbound-disk-validator-alloc: 10737418240000
   snow-mixed-query-num-push-vdr-uint: 10
+  consensus-gossip-frequency: 10000000000
+  consensus-app-concurrency: 2
   consensus-on-accept-gossip-validator-size: 0
   consensus-on-accept-gossip-non-validator-size: 0
   consensus-on-accept-gossip-peer-size: 10

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 avalanche-installer = "0.0.60" # https://crates.io/crates/avalanche-installer
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.77" # https://crates.io/crates/avalanche-telemetry-cloudwatch
-avalanche-types = { version = "0.0.339", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.57" # https://crates.io/crates/aws-ip-provisioner-installer
 aws-manager = { version = "0.25.4", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-ops = { path = "../avalanche-ops" }
-avalanche-types = { version = "0.0.339", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -9,7 +9,7 @@ name = "blizzard-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.339", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -9,7 +9,7 @@ name = "blizzardup-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.339", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.25.1" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.68"
 
 [dependencies]
-avalanche-types = { version = "0.0.339", features = ["cert"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.340", features = ["cert"] } # https://crates.io/crates/avalanche-types
 aws-manager = { version = "0.25.4", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.1", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"


### PR DESCRIPTION
ref. https://github.com/ava-labs/avalanchego/pull/1322