### PR TITLE
Support multi-region in control plane

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "avalanche-kms"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
 [dependencies]
-avalanche-types = { version = "0.0.368", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.15", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.369", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.16", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.4", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.26.1"
 dialoguer = "0.10.4"

--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 rust-version = "1.69"
 
 [dependencies]
-avalanche-types = { version = "0.0.369", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.16", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.370", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.17", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.4", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.26.1"
 dialoguer = "0.10.4"

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-avalanche-types = { version = "0.0.369", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.16", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.370", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.17", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.7"
 dir-manager = "0.0.1"
 env_logger = "0.10.0"

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-ops"
-version = "0.4.2" # https://crates.io/crates/avalanche-ops
+version = "0.5.0-alpha.0" # https://crates.io/crates/avalanche-ops
 edition = "2021"
 rust-version = "1.69"
 publish = true
@@ -10,8 +10,8 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-avalanche-types = { version = "0.0.368", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.15", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.369", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.16", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.7"
 dir-manager = "0.0.1"
 env_logger = "0.10.0"

--- a/avalanche-ops/src/aws/cfn-templates/asg_ubuntu.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/asg_ubuntu.yaml
@@ -28,6 +28,11 @@ Parameters:
     Type: String
     Description: AAD tag for envelope encryption with KMS.
 
+  S3Region:
+    Type: String
+    Default: ""
+    Description: S3 region (possibly shared across multiple regions)
+
   S3BucketName:
     Type: String
     Description: S3 bucket name.
@@ -633,14 +638,14 @@ Resources:
                 sudo mv /tmp/avalanched-aws /usr/local/bin/avalanched-aws
               else
                 sudo rm -f /tmp/avalanched-aws
-                AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=7 aws s3 cp s3://${S3BucketName}/${Id}/bootstrap/install/avalanched-aws /tmp/avalanched-aws
+                AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=7 aws s3 cp s3://${S3BucketName}/${Id}/bootstrap/install/avalanched-aws /tmp/avalanched-aws --region ${S3Region}
                 chmod +x /tmp/avalanched-aws
                 sudo mv /tmp/avalanched-aws /usr/local/bin/avalanched-aws
               fi;
               /usr/local/bin/avalanched-aws --version
 
               /usr/local/bin/avalanched-aws install-artifacts \
-              --region ${AWS::Region} \
+              --s3-region ${S3Region} \
               --s3-bucket ${S3BucketName} \
               --avalanchego-s3-key ${Id}/bootstrap/install/avalanchego \
               --avalanchego-local-path /usr/local/bin/avalanchego \
@@ -663,6 +668,7 @@ Resources:
               # --initial-wait-random-seconds=X to prevent EBS volume provision contentions
               /usr/local/bin/aws-volume-provisioner \
               --log-level=info \
+              --region ${AWS::Region} \
               --initial-wait-random-seconds=${VolumeProvisionerInitialWaitRandomSeconds} \
               --id-tag-key=Id \
               --id-tag-value=${Id} \
@@ -683,6 +689,7 @@ Resources:
                 echo "Running /usr/local/bin/aws-ip-provisioner..."
                 /usr/local/bin/aws-ip-provisioner \
                 --log-level=info \
+                --region ${AWS::Region} \
                 --id-tag-key=Id \
                 --id-tag-value=${Id} \
                 --kind-tag-key=Kind \
@@ -815,6 +822,9 @@ Resources:
           PropagateAtLaunch: true
         - Key: AAD_TAG
           Value: !Ref AadTag
+          PropagateAtLaunch: true
+        - Key: S3_REGION
+          Value: !Ref S3Region
           PropagateAtLaunch: true
         - Key: S3_BUCKET_NAME
           Value: !Ref S3BucketName

--- a/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
@@ -6,6 +6,10 @@ Description: "IAM instance role"
 
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
 Parameters:
+  RoleName:
+    Type: String
+    Description: Role name.
+
   Id:
     Type: String
     Description: Unique identifier, prefix for all resources created below.
@@ -30,7 +34,7 @@ Resources:
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ["-", [!Ref Id, "instance-role"]]
+      RoleName: !Ref RoleName
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
@@ -10,6 +10,10 @@ Parameters:
     Type: String
     Description: Role name.
 
+  RoleProfileName:
+    Type: String
+    Description: Role profile name.
+
   Id:
     Type: String
     Description: Unique identifier, prefix for all resources created below.
@@ -187,7 +191,7 @@ Resources:
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: !Join ["-", [!Ref Id, "instance-profile"]]
+      InstanceProfileName: !Ref RoleProfileName
       Path: "/"
       Roles:
         - !Ref InstanceRole

--- a/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/ec2_instance_role.yaml
@@ -18,24 +18,12 @@ Parameters:
     Type: String
     Description: S3 bucket name to store.
 
-  S3BucketDbBackupName:
-    Type: String
-    Default: ""
-    Description: S3 bucket name to download backups from.
-
 Mappings:
   ServicePrincipals:
     aws-cn:
       ec2: ec2.amazonaws.com.cn
     aws:
       ec2: ec2.amazonaws.com
-
-Conditions:
-  HasS3BucketDbBackupName:
-    Fn::Not:
-      - Fn::Equals:
-          - Ref: S3BucketDbBackupName
-          - ""
 
 Resources:
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
@@ -60,6 +48,8 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
       Path: /
       Policies:
+        # restrict this better
+        # ref. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_ec2_ebs-owner.html
         - PolicyName: avalanched-instance-role-policy
           PolicyDocument:
             Version: "2012-10-17"
@@ -75,9 +65,8 @@ Resources:
                   - ec2:DetachVolume # to fail fast in case of spot instance-action
                   - autoscaling:SetInstanceHealth # to fail fast to mark the local instance "Unhealthy"
                   - ec2:TerminateInstances # to fail fast in case of spot instance-action
-                # restrict this better
-                # ref. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_ec2_ebs-owner.html
                 Resource: "*"
+
               - Effect: Allow
                 Action:
                   - kms:Encrypt # to generate TLS key and encrypt
@@ -88,6 +77,7 @@ Resources:
                 Action:
                   - s3:List*
                 Resource: "*"
+
               - Effect: Allow
                 Action:
                   - s3:GetObject # to download artifacts
@@ -163,10 +153,12 @@ Resources:
                         "/ssm-output-logs/*",
                       ],
                     ]
+
               - Effect: Allow
                 Action:
                   - cloudwatch:PutMetricData
                 Resource: "*"
+
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
@@ -186,26 +178,6 @@ Resources:
                   - ec2:AssociateAddress # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html
                   - ec2:DescribeAddresses # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAddresses.html
                 Resource: "*"
-
-        - Fn::If:
-            - HasS3BucketDbBackupName
-            - PolicyName: avalanche-ops-instance-role-policy-for-db-backup
-              PolicyDocument:
-                Version: "2012-10-17"
-                Statement:
-                  - Effect: Allow
-                    Action:
-                      - s3:GetObject # to download backups
-                    Resource:
-                      - !Join [
-                          "",
-                          [
-                            !Sub "arn:${AWS::Partition}:s3:::",
-                            !Ref S3BucketDbBackupName,
-                            "/*",
-                          ],
-                        ]
-            - !Ref AWS::NoValue
 
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html
   InstanceProfile:

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -572,6 +572,7 @@ impl Spec {
                 panic!("auto-regions only supported up to 5 regions!")
             }
         }
+        log::info!("generating configuration with the regions {:?}", regions);
 
         let region_to_instance_types = if !opts.instance_types.is_empty() {
             opts.instance_types.clone()

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -134,6 +134,7 @@ pub struct Resource {
 
     /// Only populate as many as we need to fill up anchor/non-anchor nodes.
     /// e.g., "regions" may have 5 but we may only need 2 regions for 3 node cluster.
+    #[serde(default)]
     pub regional_resources: HashMap<String, RegionalResource>,
 
     /// Created nodes at the start of the network.
@@ -1162,7 +1163,7 @@ id: {id}
 aad_tag: test
 
 resource:
-  regional_resources:
+  regions:
   - us-west-2
   s3_bucket: {bucket}
   use_spot_instance: false

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -337,7 +337,7 @@ pub struct DefaultSpecOption {
     pub keys_to_generate: usize,
 
     pub regions: Vec<String>,
-    pub auto_regions: usize,
+    pub auto_regions: u32,
 
     pub ingress_ipv4_cidr: String,
     pub instance_mode: String,

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -132,6 +132,8 @@ pub struct Resource {
     #[serde(default)]
     pub ingress_ipv4_cidr: String,
 
+    /// Only populate as many as we need to fill up anchor/non-anchor nodes.
+    /// e.g., "regions" may have 5 but we may only need 2 regions for 3 node cluster.
     pub regional_resources: HashMap<String, RegionalResource>,
 
     /// Created nodes at the start of the network.

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -1780,7 +1780,7 @@ impl UploadArtifacts {
 
 /// Represents the CloudFormation stack name.
 pub enum StackName {
-    Ec2InstanceRole(String),
+    Ec2InstanceRole(String, String),
     Vpc(String),
     SsmInstallSubnetChain(String),
 }
@@ -1788,7 +1788,7 @@ pub enum StackName {
 impl StackName {
     pub fn encode(&self) -> String {
         match self {
-            StackName::Ec2InstanceRole(id) => format!("{}-ec2-instance-role", id),
+            StackName::Ec2InstanceRole(id, region) => format!("{id}-ec2-instance-role-{region}"),
             StackName::Vpc(id) => format!("{}-vpc", id),
             StackName::SsmInstallSubnetChain(id) => {
                 format!("{id}-ssm-install-subnet-chain")

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs::{self, File},
     io::{self, Error, ErrorKind, Write},
     path::Path,
@@ -135,7 +135,7 @@ pub struct Resource {
     /// Only populate as many as we need to fill up anchor/non-anchor nodes.
     /// e.g., "regions" may have 5 but we may only need 2 regions for 3 node cluster.
     #[serde(default)]
-    pub regional_resources: HashMap<String, RegionalResource>,
+    pub regional_resources: BTreeMap<String, RegionalResource>,
 
     /// Created nodes at the start of the network.
     /// May become stale.
@@ -158,7 +158,7 @@ impl Resource {
             s3_bucket: String::new(),
             ingress_ipv4_cidr: String::from("0.0.0.0/0"),
 
-            regional_resources: HashMap::new(),
+            regional_resources: BTreeMap::new(),
 
             created_nodes: None,
         }
@@ -590,8 +590,8 @@ impl Spec {
         let mut current_anchor_nodes = 0_u32;
         let mut current_non_anchor_nodes = 0_u32;
 
-        let mut regional_resources = HashMap::new();
-        let mut regional_machines = HashMap::new();
+        let mut regional_resources = BTreeMap::new();
+        let mut regional_machines = BTreeMap::new();
 
         for (i, reg) in regions.iter().enumerate() {
             let mut regional_machine = RegionalMachine {
@@ -1288,7 +1288,7 @@ coreth_chain_config:
 
     cfg.sync(config_path).unwrap();
 
-    let mut regional_machines = HashMap::new();
+    let mut regional_machines = BTreeMap::new();
     regional_machines.insert(
         "us-west-2".to_string(),
         RegionalMachine {
@@ -1713,7 +1713,7 @@ pub struct Machine {
     pub volume_size_in_gb: u32,
 
     #[serde(default)]
-    pub regional_machines: HashMap<String, RegionalMachine>,
+    pub regional_machines: BTreeMap<String, RegionalMachine>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanched-aws"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
@@ -12,9 +12,9 @@ path = "src/main.rs"
 avalanche-installer = "0.0.67" # https://crates.io/crates/avalanche-installer
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.93" # https://crates.io/crates/avalanche-telemetry-cloudwatch
-avalanche-types = { version = "0.0.368", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.369", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.73" # https://crates.io/crates/aws-ip-provisioner-installer
-aws-manager = { version = "0.26.15", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.26.16", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/main.rs"
 avalanche-installer = "0.0.67" # https://crates.io/crates/avalanche-installer
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.93" # https://crates.io/crates/avalanche-telemetry-cloudwatch
-avalanche-types = { version = "0.0.369", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.370", features = ["avalanchego", "cert", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.73" # https://crates.io/crates/aws-ip-provisioner-installer
-aws-manager = { version = "0.26.16", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.26.17", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalanched-aws/src/install_artifacts/mod.rs
+++ b/avalanched-aws/src/install_artifacts/mod.rs
@@ -24,10 +24,10 @@ pub fn command() -> Command {
                 .default_value("info"),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .help("Sets the AWS region")
-                .required(false)
+            Arg::new("S3_REGION")
+                .long("s3-region")
+                .help("Sets the AWS S3 region")
+                .required(true)
                 .num_args(1),
         )
         .arg(
@@ -116,7 +116,7 @@ pub fn command() -> Command {
 /// 3. If the S3 download fails, fall back to github downloads.
 pub async fn execute(
     log_level: &str,
-    region: &str,
+    s3_region: &str,
     s3_bucket: &str,
     avalanchego_s3_key: &str,
     avalanchego_local_path: &str,
@@ -135,7 +135,7 @@ pub async fn execute(
     );
 
     let shared_config =
-        aws_manager::load_config(Some(region.to_string()), Some(Duration::from_secs(30))).await;
+        aws_manager::load_config(Some(s3_region.to_string()), Some(Duration::from_secs(30))).await;
     let s3_manager = s3::Manager::new(&shared_config);
 
     let need_github_download = if !avalanchego_s3_key.is_empty() {

--- a/avalanched-aws/src/install_artifacts/mod.rs
+++ b/avalanched-aws/src/install_artifacts/mod.rs
@@ -146,6 +146,8 @@ pub async fn execute(
                 avalanchego_s3_key,
                 avalanchego_local_path,
                 true,
+                Duration::from_secs(30),
+                Duration::from_secs(1),
             )
             .await
             .unwrap();
@@ -170,6 +172,8 @@ pub async fn execute(
                 aws_volume_provisioner_s3_key,
                 aws_volume_provisioner_local_path,
                 true,
+                Duration::from_secs(30),
+                Duration::from_secs(1),
             )
             .await
             .unwrap();
@@ -201,6 +205,8 @@ pub async fn execute(
                 aws_ip_provisioner_s3_key,
                 aws_ip_provisioner_local_path,
                 true,
+                Duration::from_secs(30),
+                Duration::from_secs(1),
             )
             .await
             .unwrap();
@@ -232,6 +238,8 @@ pub async fn execute(
                 avalanche_telemetry_cloudwatch_s3_key,
                 avalanche_telemetry_cloudwatch_local_path,
                 true,
+                Duration::from_secs(30),
+                Duration::from_secs(1),
             )
             .await
             .unwrap();

--- a/avalanched-aws/src/install_chain/mod.rs
+++ b/avalanched-aws/src/install_chain/mod.rs
@@ -16,7 +16,7 @@ pub const NAME: &str = "install-chain";
 pub struct Flags {
     pub log_level: String,
 
-    pub region: String,
+    pub s3_region: String,
     pub s3_bucket: String,
 
     pub chain_config_s3_key: String,
@@ -37,9 +37,9 @@ pub fn command() -> Command {
                 .default_value("info"),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .help("Sets the AWS region")
+            Arg::new("S3_REGION")
+                .long("s3-region")
+                .help("Sets the AWS S3 region")
                 .required(true)
                 .num_args(1),
         )
@@ -73,7 +73,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     );
 
     let shared_config =
-        aws_manager::load_config(Some(opts.region.clone()), Some(Duration::from_secs(30))).await;
+        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
     let s3_manager = s3::Manager::new(&shared_config);
 
     let path = Path::new(&opts.chain_config_local_path);

--- a/avalanched-aws/src/install_chain/mod.rs
+++ b/avalanched-aws/src/install_chain/mod.rs
@@ -97,6 +97,8 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             &opts.chain_config_s3_key,
             &opts.chain_config_local_path,
             true,
+            Duration::from_secs(30),
+            Duration::from_secs(1),
         )
         .await
         .unwrap();

--- a/avalanched-aws/src/install_subnet/mod.rs
+++ b/avalanched-aws/src/install_subnet/mod.rs
@@ -136,6 +136,8 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
                 &opts.subnet_config_s3_key,
                 &opts.subnet_config_local_path,
                 true,
+                Duration::from_secs(30),
+                Duration::from_secs(1),
             )
             .await
             .unwrap();
@@ -171,6 +173,8 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
                 &opts.vm_binary_s3_key,
                 &opts.vm_binary_local_path,
                 true,
+                Duration::from_secs(30),
+                Duration::from_secs(1),
             )
             .await
             .unwrap();

--- a/avalanched-aws/src/install_subnet/mod.rs
+++ b/avalanched-aws/src/install_subnet/mod.rs
@@ -18,7 +18,7 @@ pub const NAME: &str = "install-subnet";
 pub struct Flags {
     pub log_level: String,
 
-    pub region: String,
+    pub s3_region: String,
     pub s3_bucket: String,
 
     pub subnet_config_s3_key: String,
@@ -47,9 +47,9 @@ pub fn command() -> Command {
                 .default_value("info"),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .help("Sets the AWS region")
+            Arg::new("S3_REGION")
+                .long("s3-region")
+                .help("Sets the AWS S3 region")
                 .required(true)
                 .num_args(1),
         )
@@ -111,7 +111,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     );
 
     let shared_config =
-        aws_manager::load_config(Some(opts.region.clone()), Some(Duration::from_secs(30))).await;
+        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
     let s3_manager = s3::Manager::new(&shared_config);
 
     if !opts.subnet_config_s3_key.is_empty() && !opts.subnet_config_s3_key.is_empty() {

--- a/avalanched-aws/src/main.rs
+++ b/avalanched-aws/src/main.rs
@@ -47,9 +47,7 @@ async fn main() {
                     .get_one::<String>("LOG_LEVEL")
                     .unwrap_or(&String::from("info"))
                     .clone(),
-                &sub_matches
-                    .get_one::<String>("REGION")
-                    .unwrap_or(&String::new()),
+                &sub_matches.get_one::<String>("S3_REGION").unwrap(),
                 &sub_matches
                     .get_one::<String>("S3_BUCKET")
                     .unwrap_or(&String::new()),
@@ -92,7 +90,10 @@ async fn main() {
                     .get_one::<String>("LOG_LEVEL")
                     .unwrap_or(&String::from("info"))
                     .to_string(),
-                region: sub_matches.get_one::<String>("REGION").unwrap().to_string(),
+                s3_region: sub_matches
+                    .get_one::<String>("S3_REGION")
+                    .unwrap()
+                    .to_string(),
                 s3_bucket: sub_matches
                     .get_one::<String>("S3_BUCKET")
                     .unwrap()
@@ -132,7 +133,10 @@ async fn main() {
                     .get_one::<String>("LOG_LEVEL")
                     .unwrap_or(&String::from("info"))
                     .to_string(),
-                region: sub_matches.get_one::<String>("REGION").unwrap().to_string(),
+                s3_region: sub_matches
+                    .get_one::<String>("S3_REGION")
+                    .unwrap()
+                    .to_string(),
                 s3_bucket: sub_matches
                     .get_one::<String>("S3_BUCKET")
                     .unwrap()

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-ops = { path = "../avalanche-ops" }
-avalanche-types = { version = "0.0.369", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.16", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.370", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.17", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalancheup-aws"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
@@ -10,8 +10,8 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-ops = { path = "../avalanche-ops" }
-avalanche-types = { version = "0.0.368", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.15", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.369", features = ["avalanchego", "cert", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.16", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/recipes-aws-advanced.md
+++ b/avalancheup-aws/recipes-aws-advanced.md
@@ -555,7 +555,7 @@ cd ${HOME}/avalanche-ops
 --upload-artifacts-avalanched-aws-local-bin ${AVALANCHED_BIN_PATH} \
 --upload-artifacts-avalanchego-local-bin ${AVALANCHE_BIN_PATH} \
 --upload-artifacts-plugin-local-dir ${AVALANCHE_PLUGINS_DIR_PATH} \
---nlb-acm-certificate-arn $ACM_CERT_ARN \
+--nlb-acm-certificate-arns '{"us-west-2": "$ACM_CERT_ARN"}\
 --network-name custom \
 --avalanchego-log-level INFO
 

--- a/avalancheup-aws/src/add_primary_network_validators/mod.rs
+++ b/avalancheup-aws/src/add_primary_network_validators/mod.rs
@@ -27,7 +27,7 @@ pub struct Flags {
     pub key: String,
     pub primary_network_validate_period_in_days: u64,
     pub staking_amount_in_avax: u64,
-    pub node_ids_to_instance_ids: HashMap<String, String>,
+    pub target_node_ids: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -78,7 +78,7 @@ pub fn command() -> Command {
             Arg::new("SPEC_FILE_PATH")
                 .long("spec-file-path")
                 .short('s')
-                .help("The spec file to load and update (used for adding permissionless validators)")
+                .help("The spec file to load and update (used for adding permissionless validators, overwrites --target-node-ids)")
                 .required(false)
                 .num_args(1),
         )
@@ -117,9 +117,9 @@ pub fn command() -> Command {
                 .default_value("2000"),
         )
         .arg(
-            Arg::new("NODE_IDS_TO_INSTANCE_IDS")
-                .long("node-ids-to-instance-ids")
-                .help("Sets the hash map of node Id to instance Id in JSON format")
+            Arg::new("TARGET_NODE_IDS")
+                .long("target-node-ids")
+                .help("Sets the hash map of node Id to instance Id in JSON format (discarded when non-empty --spec-file-path)")
                 .required(false)
                 .value_parser(HashMapParser {})
                 .num_args(1),
@@ -146,7 +146,9 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             }
         }
     } else {
-        node_ids_to_instance_ids = opts.node_ids_to_instance_ids.clone();
+        for node_id in &opts.target_node_ids {
+            node_ids_to_instance_ids.insert(node_id.clone(), "unknown".to_string());
+        }
     }
 
     let resp = json_client_info::get_network_id(&opts.chain_rpc_url)
@@ -172,11 +174,9 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     );
 
     let mut all_node_ids = Vec::new();
-    let mut all_instance_ids = Vec::new();
     for (node_id, instance_id) in node_ids_to_instance_ids.iter() {
         log::info!("will send SSM doc to {node_id} {instance_id}");
         all_node_ids.push(node_id.clone());
-        all_instance_ids.push(instance_id.clone());
     }
 
     // if all nodes need to be staked

--- a/avalancheup-aws/src/add_primary_network_validators/mod.rs
+++ b/avalancheup-aws/src/add_primary_network_validators/mod.rs
@@ -138,7 +138,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         let spec = avalanche_ops::aws::spec::Spec::load(&opts.spec_file_path)
             .expect("failed to load spec");
         spec.validate()?;
-        if let Some(created_nodes) = &spec.resources.created_nodes {
+        if let Some(created_nodes) = &spec.resource.created_nodes {
             for node in created_nodes {
                 let node_id = ids::node::Id::from_str(&node.node_id).unwrap();
                 node_id_to_pop.insert(node_id, node.proof_of_possession.clone());

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -2243,7 +2243,7 @@ cat /tmp/{node_id}.crt
 --key {priv_key_hex} \\
 --primary-network-validate-period-in-days 16 \\
 --staking-amount-in-avax 2000 \\
---spec-file-path {spec_file_path} \\
+--spec-file-path {spec_file_path}
 
 # or
 # --target-node-ids '{target_node_ids}'

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -1256,6 +1256,7 @@ aws ssm start-session --region {} --target {}
 
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let mut regional_resource = r.clone();
+        let regional_machine = spec.machine.regional_machines.get(region).clone().unwrap();
 
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
@@ -1284,7 +1285,7 @@ aws ssm start-session --region {} --target {}
                 .clone()
                 .unwrap();
 
-            let non_anchor_nodes = spec.machine.total_non_anchor_nodes;
+            let regional_non_anchor_nodes = regional_machine.non_anchor_nodes;
 
             // must deep-copy as shared with other node kind
             let mut common_asg_params_non_anchor = common_asg_params.clone();
@@ -1296,7 +1297,7 @@ aws ssm start-session --region {} --target {}
                 .unwrap();
 
             let mut non_anchor_asg_logical_ids = Vec::new();
-            for i in 0..non_anchor_nodes as usize {
+            for i in 0..regional_non_anchor_nodes as usize {
                 let mut non_anchor_asg_params = common_asg_params_non_anchor.clone();
                 non_anchor_asg_params.push(build_param(
                     "PublicSubnetIds",
@@ -1401,7 +1402,7 @@ aws ssm start-session --region {} --target {}
                     }
                 }
             }
-            for i in 1..non_anchor_nodes as usize {
+            for i in 1..regional_non_anchor_nodes as usize {
                 let mut wait_secs = 800;
                 if wait_secs > MAX_WAIT_SECONDS {
                     wait_secs = MAX_WAIT_SECONDS;

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -1941,6 +1941,7 @@ cat /tmp/{node_id}.crt
     //
     //
     //
+    let mut region_to_ssm_doc = HashMap::new();
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
@@ -1959,6 +1960,11 @@ cat /tmp/{node_id}.crt
             .unwrap();
         let ssm_install_subnet_chain_doc_name =
             avalanche_ops::aws::spec::StackName::SsmInstallSubnetChain(spec.id.clone()).encode();
+        region_to_ssm_doc.insert(
+            region.to_string(),
+            ssm_install_subnet_chain_doc_name.clone(),
+        );
+
         let cfn_params = Vec::from([build_param(
             "DocumentName",
             &ssm_install_subnet_chain_doc_name,

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -512,6 +512,7 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
                 .unwrap();
 
             let role_params = Vec::from([
+                build_param("RoleName", format!("{}-{region}", &spec.id).as_str()),
                 build_param("Id", &spec.id),
                 build_param(
                     "KmsKeyArn",

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -691,7 +691,6 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
-        let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
         let mut common_asg_params = Vec::from([
             build_param("Id", &spec.id),
@@ -1044,7 +1043,6 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
 
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
-        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
         let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
         if let Some(anchor_asg_logical_ids) =
@@ -1249,12 +1247,10 @@ aws ssm start-session --region {} --target {}
 
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let mut regional_resource = r.clone();
-        let regional_machine = spec.machine.regional_machines.get(region).clone().unwrap();
 
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
-        let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
         let common_asg_params = region_to_common_asg_params.get(region).unwrap();
 
@@ -1499,10 +1495,7 @@ aws ssm start-session --region {} --target {}
 
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
-        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
         let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
-
-        let common_asg_params = region_to_common_asg_params.get(region).unwrap();
 
         if let Some(non_anchor_asg_logical_ids) =
             &regional_resource.cloudformation_asg_non_anchor_nodes_logical_ids
@@ -1728,7 +1721,7 @@ aws ssm start-session --region {} --target {}
     let mut rpc_hosts = Vec::new();
     let mut rpc_host_to_node = HashMap::new();
     let mut nlb_https_enabled = false;
-    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+    for (_, regional_resource) in spec.resource.regional_resources.clone().iter() {
         nlb_https_enabled = regional_resource.nlb_acm_certificate_arn.is_some();
 
         if let Some(dns_name) = &regional_resource.cloudformation_asg_nlb_dns_name {

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -111,7 +111,11 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
         }
         if regional_resource.cloudformation_ec2_instance_role.is_none() {
             regional_resource.cloudformation_ec2_instance_role = Some(
-                avalanche_ops::aws::spec::StackName::Ec2InstanceRole(spec.id.clone()).encode(),
+                avalanche_ops::aws::spec::StackName::Ec2InstanceRole(
+                    spec.id.clone(),
+                    region.clone(),
+                )
+                .encode(),
             );
         }
         if regional_resource.cloudformation_vpc.is_none() {

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -2186,20 +2186,17 @@ cat /tmp/{node_id}.crt
         ResetColor
     )?;
 
-    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-        println!("\n# EXAMPLE: install subnet-evm in all nodes (including adding all nodes as primary network validators, works for any VM)");
-
-        let region_to_ssm_doc_name = serde_json::to_string(&region_to_ssm_doc_name).unwrap();
-        let node_id_to_region_machine_id =
-            serde_json::to_string(&node_id_to_region_machine_id).unwrap();
-
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Green),
-            Print(format!(
-                "{exec_path} install-subnet-chain \\
+    println!("\n# EXAMPLE: install subnet-evm in all nodes (including adding all nodes as primary network validators, works for any VM)");
+    let region_to_ssm_doc_name = serde_json::to_string(&region_to_ssm_doc_name).unwrap();
+    let node_id_to_region_machine_id =
+        serde_json::to_string(&node_id_to_region_machine_id).unwrap();
+    execute!(
+        stdout(),
+        SetForegroundColor(Color::Green),
+        Print(format!(
+            "{exec_path} install-subnet-chain \\
 --log-level info \\
---s3-region {region} \\
+--s3-region {s3_region} \\
 --s3-bucket {s3_bucket} \\
 --s3-key-prefix {id}/install-subnet-chain \\
 --chain-rpc-url {chain_rpc_url} \\
@@ -2222,25 +2219,23 @@ cat /tmp/{node_id}.crt
 # or use to add all nodes as subnet validators
 # --spec-file-path {spec_file_path}
 ",
-                exec_path = exec_path.display(),
-                region = region,
-                s3_bucket = spec.resource.s3_bucket,
-                chain_rpc_url =
-                    format!("{}://{}:{}", scheme_for_dns, rpc_hosts[0], port_for_dns).to_string(),
-                priv_key_hex = key::secp256k1::TEST_KEYS[0].to_hex(),
-                id = spec.id,
-                subnet_config_remote_dir = spec.avalanchego_config.subnet_config_dir,
-                vm_plugin_remote_dir = spec.avalanchego_config.plugin_dir,
-                chain_config_remote_dir = spec.avalanchego_config.chain_config_dir,
-                avalanchego_config_remote_path =
-                    spec.avalanchego_config.config_file.clone().unwrap(),
-                region_to_ssm_doc_name = region_to_ssm_doc_name,
-                node_id_to_region_machine_id = node_id_to_region_machine_id,
-                spec_file_path = spec_file_path,
-            )),
-            ResetColor
-        )?;
-    }
+            exec_path = exec_path.display(),
+            s3_region = spec.resource.regions[0],
+            s3_bucket = spec.resource.s3_bucket,
+            chain_rpc_url =
+                format!("{}://{}:{}", scheme_for_dns, rpc_hosts[0], port_for_dns).to_string(),
+            priv_key_hex = key::secp256k1::TEST_KEYS[0].to_hex(),
+            id = spec.id,
+            subnet_config_remote_dir = spec.avalanchego_config.subnet_config_dir,
+            vm_plugin_remote_dir = spec.avalanchego_config.plugin_dir,
+            chain_config_remote_dir = spec.avalanchego_config.chain_config_dir,
+            avalanchego_config_remote_path = spec.avalanchego_config.config_file.clone().unwrap(),
+            region_to_ssm_doc_name = region_to_ssm_doc_name,
+            node_id_to_region_machine_id = node_id_to_region_machine_id,
+            spec_file_path = spec_file_path,
+        )),
+        ResetColor
+    )?;
 
     println!("\n# EXAMPLE: start distributed load generator");
     execute!(

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -606,7 +606,7 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     }
 
     for (region, r) in spec.resource.regional_resources.clone().iter() {
-        let mut regional_resource = r.clone();
+        let regional_resource = r.clone();
 
         let regional_shared_config =
             aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -512,7 +512,11 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
                 .unwrap();
 
             let role_params = Vec::from([
-                build_param("RoleName", format!("{}-{region}", &spec.id).as_str()),
+                build_param("RoleName", format!("{}-{region}-role", &spec.id).as_str()),
+                build_param(
+                    "RoleProfileName",
+                    format!("{}-{region}-role-profile", &spec.id).as_str(),
+                ),
                 build_param("Id", &spec.id),
                 build_param(
                     "KmsKeyArn",

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -137,6 +137,7 @@ pub fn command() -> Command {
                 .help("Sets the number of regions to auto-populate (overwrites --region)")
                 .required(false)
                 .num_args(1)
+                .value_parser(value_parser!(u32))
                 .default_value("1"),
         )
         .arg(

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -83,6 +83,14 @@ pub fn command() -> Command {
                 .default_value("us-west-2"),
         )
         .arg(
+            Arg::new("AUTO_REGIONS")
+                .long("auto-regions")
+                .help("Sets the number of regions to auto-populate (overwrites --region)")
+                .required(false)
+                .num_args(1)
+                .default_value("1"),
+        )
+        .arg(
             Arg::new("INGRESS_IPV4_CIDR")
                 .long("ingress-ipv4-cidr")
                 .help("Sets the IPv4 CIDR range for ingress traffic HTTP/SSH (leave empty to default to public IP on the local host)")

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -1,4 +1,7 @@
-use std::io::{self, stdout};
+use std::{
+    collections::HashMap,
+    io::{self, stdout},
+};
 
 use avalanche_types::avalanchego::config as avalanchego_config;
 use clap::{value_parser, Arg, Command};
@@ -8,6 +11,52 @@ use crossterm::{
 };
 
 pub const NAME: &str = "default-spec";
+
+#[derive(Clone, Debug)]
+pub struct HashMapStringToStringParser;
+
+impl clap::builder::TypedValueParser for HashMapStringToStringParser {
+    type Value = HashMap<String, String>;
+
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let str = value.to_str().unwrap_or_default();
+        let m: HashMap<String, String> = serde_json::from_str(str).map_err(|e| {
+            clap::Error::raw(
+                clap::error::ErrorKind::InvalidValue,
+                format!("HashMap parsing failed ({})", e),
+            )
+        })?;
+        Ok(m)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HashMapStringToStringsParser;
+
+impl clap::builder::TypedValueParser for HashMapStringToStringsParser {
+    type Value = HashMap<String, Vec<String>>;
+
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let str = value.to_str().unwrap_or_default();
+        let m: HashMap<String, Vec<String>> = serde_json::from_str(str).map_err(|e| {
+            clap::Error::raw(
+                clap::error::ErrorKind::InvalidValue,
+                format!("HashMap parsing failed ({})", e),
+            )
+        })?;
+        Ok(m)
+    }
+}
 
 pub fn command() -> Command {
     Command::new(NAME)
@@ -118,8 +167,9 @@ pub fn command() -> Command {
         .arg(
             Arg::new("INSTANCE_TYPES")
                 .long("instance-types")
-                .help("Sets the comma-separated instance types (overwrites --instance-size)")
+                .help("Sets the hash map from a region to a comma-separated instance types (overwrites --instance-size)")
                 .required(false)
+                .value_parser(HashMapStringToStringsParser {})
                 .num_args(1),
         )
         .arg(
@@ -139,10 +189,11 @@ pub fn command() -> Command {
                 .num_args(0),
         )
         .arg(
-            Arg::new("NLB_ACM_CERTIFICATE_ARN") 
-                .long("nlb-acm-certificate-arn")
-                .help("Sets ACM ARN to enable NLB HTTPS")
+            Arg::new("NLB_ACM_CERTIFICATE_ARNS") 
+                .long("nlb-acm-certificate-arns")
+                .help("Sets the hash map from a region to an ACM ARN to enable NLB HTTPS")
                 .required(false)
+                .value_parser(HashMapStringToStringParser {})
                 .num_args(1),
         )
         .arg(

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -75,10 +75,9 @@ pub fn command() -> Command {
                 .default_value("0"),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .short('r')
-                .help("Sets the AWS region for API calls/endpoints")
+            Arg::new("REGIONS")
+                .long("regions")
+                .help("Sets the comma-separated instance types (overwrites --region)")
                 .required(false)
                 .num_args(1)
                 .default_value("us-west-2"),

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -583,7 +583,7 @@ pub async fn execute(
     }
 
     if delete_elastic_ips {
-        for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        for (region, _) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config =
                 aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -102,7 +102,7 @@ pub async fn execute(
     let spec = avalanche_ops::aws::spec::Spec::load(spec_file_path).expect("failed to load spec");
 
     let shared_config = aws_manager::load_config(
-        Some(spec.resources.region.clone()),
+        Some(spec.resources.regions[0].clone()),
         Some(Duration::from_secs(30)),
     )
     .await;

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -473,7 +473,7 @@ pub async fn execute(
     }
 
     if delete_cloudwatch_log_group {
-        for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        for (region, _) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config =
                 aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
@@ -533,7 +533,7 @@ pub async fn execute(
     }
 
     if delete_ebs_volumes {
-        for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        for (region, _) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config =
                 aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -152,149 +152,253 @@ pub async fn execute(
 
     log::info!("deleting resources...");
     let s3_manager = s3::Manager::new(&shared_config);
-    let kms_manager = kms::Manager::new(&shared_config);
-    let ec2_manager = ec2::Manager::new(&shared_config);
-    let cloudformation_manager = cloudformation::Manager::new(&shared_config);
-    let cw_manager = cloudwatch::Manager::new(&shared_config);
 
-    // delete this first since EC2 key delete does not depend on ASG/VPC
-    // (mainly to speed up delete operation)
-    execute!(
-        stdout(),
-        SetForegroundColor(Color::Red),
-        Print("\n\n\nSTEP: delete EC2 key pair\n"),
-        ResetColor
-    )?;
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
-    let ec2_key_path = spec.resource.ec2_key_path.clone();
-    if Path::new(ec2_key_path.as_str()).exists() {
-        fs::remove_file(ec2_key_path.as_str()).unwrap();
-    }
-    let ec2_key_path_compressed = format!(
-        "{}{}",
-        ec2_key_path,
-        compress_manager::Encoder::Zstd(3).ext()
-    );
-    if Path::new(ec2_key_path_compressed.as_str()).exists() {
-        fs::remove_file(ec2_key_path_compressed.as_str()).unwrap();
-    }
-    let ec2_key_path_compressed_encrypted = format!("{}.encrypted", ec2_key_path_compressed);
-    if Path::new(ec2_key_path_compressed_encrypted.as_str()).exists() {
-        fs::remove_file(ec2_key_path_compressed_encrypted.as_str()).unwrap();
-    }
-    ec2_manager
-        .delete_key_pair(&spec.resource.ec2_key_name)
-        .await
-        .unwrap();
+        let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
+        let regional_kms_manager = kms::Manager::new(&regional_shared_config);
 
-    // delete this first since KMS key delete does not depend on ASG/VPC
-    // (mainly to speed up delete operation)
-    if spec.resource.kms_symmetric_default_encrypt_key.is_some() {
-        sleep(Duration::from_secs(1)).await;
-
+        // delete this first since EC2 key delete does not depend on ASG/VPC
+        // (mainly to speed up delete operation)
         execute!(
             stdout(),
             SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: delete KMS key for encryption\n"),
+            Print(format!(
+                "\n\n\nSTEP: delete EC2 key pair in the region '{region}'\n"
+            )),
             ResetColor
         )?;
 
-        let k = spec.resource.kms_symmetric_default_encrypt_key.unwrap();
-        kms_manager
-            .schedule_to_delete(k.id.as_str(), 7)
+        let ec2_key_path = regional_resource.ec2_key_path.clone();
+        if Path::new(ec2_key_path.as_str()).exists() {
+            fs::remove_file(ec2_key_path.as_str()).unwrap();
+        }
+        let ec2_key_path_compressed = format!(
+            "{}{}",
+            ec2_key_path,
+            compress_manager::Encoder::Zstd(3).ext()
+        );
+        if Path::new(ec2_key_path_compressed.as_str()).exists() {
+            fs::remove_file(ec2_key_path_compressed.as_str()).unwrap();
+        }
+        let ec2_key_path_compressed_encrypted = format!("{}.encrypted", ec2_key_path_compressed);
+        if Path::new(ec2_key_path_compressed_encrypted.as_str()).exists() {
+            fs::remove_file(ec2_key_path_compressed_encrypted.as_str()).unwrap();
+        }
+        regional_ec2_manager
+            .delete_key_pair(&regional_resource.ec2_key_name)
             .await
             .unwrap();
-    }
 
-    // IAM roles can be deleted without being blocked on ASG/VPC
-    if spec
-        .resource
-        .cloudformation_ec2_instance_profile_arn
-        .is_some()
-    {
-        sleep(Duration::from_secs(1)).await;
+        // delete this first since KMS key delete does not depend on ASG/VPC
+        // (mainly to speed up delete operation)
+        if regional_resource
+            .kms_symmetric_default_encrypt_key
+            .is_some()
+        {
+            sleep(Duration::from_secs(1)).await;
 
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: trigger delete EC2 instance role\n"),
-            ResetColor
-        )?;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: delete KMS key for encryption in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
 
-        let ec2_instance_role_stack_name = spec
-            .resource
-            .cloudformation_ec2_instance_role
-            .clone()
-            .unwrap();
-        cloudformation_manager
-            .delete_stack(ec2_instance_role_stack_name.as_str())
-            .await
-            .unwrap();
-    }
-
-    if let Some(ssm_doc_stack_name) = &spec.resource.cloudformation_ssm_install_subnet_chain {
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: triggering delete SSM document for installing subnet\n"),
-            ResetColor
-        )?;
-        cloudformation_manager
-            .delete_stack(ssm_doc_stack_name)
-            .await
-            .unwrap();
-    }
-
-    // delete no matter what, in case node provision failed
-    sleep(Duration::from_secs(1)).await;
-    execute!(
-        stdout(),
-        SetForegroundColor(Color::Red),
-        Print("\n\n\nSTEP: triggering delete ASG for non-anchor nodes\n"),
-        ResetColor
-    )?;
-    if let Some(stack_names) = &spec.resource.cloudformation_asg_non_anchor_nodes {
-        for stack_name in stack_names.iter() {
-            sleep(Duration::from_millis(200)).await;
-            cloudformation_manager
-                .delete_stack(stack_name)
+            let k = regional_resource
+                .kms_symmetric_default_encrypt_key
+                .clone()
+                .unwrap();
+            regional_kms_manager
+                .schedule_to_delete(k.id.as_str(), 7)
                 .await
                 .unwrap();
         }
     }
 
-    execute!(
-        stdout(),
-        SetForegroundColor(Color::Red),
-        Print("\n\n\nSTEP: triggering delete ASG for anchor nodes\n"),
-        ResetColor
-    )?;
-    if let Some(stack_names) = &spec.resource.cloudformation_asg_anchor_nodes {
-        for stack_name in stack_names.iter() {
-            sleep(Duration::from_millis(200)).await;
-            cloudformation_manager
-                .delete_stack(stack_name)
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+
+        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
+
+        // IAM roles can be deleted without being blocked on ASG/VPC
+        if regional_resource
+            .cloudformation_ec2_instance_profile_arn
+            .is_some()
+        {
+            sleep(Duration::from_secs(1)).await;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: trigger delete EC2 instance role in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
+
+            let ec2_instance_role_stack_name = regional_resource
+                .cloudformation_ec2_instance_role
+                .clone()
+                .unwrap();
+            regional_cloudformation_manager
+                .delete_stack(ec2_instance_role_stack_name.as_str())
+                .await
+                .unwrap();
+        }
+
+        if let Some(ssm_doc_stack_name) = &regional_resource.cloudformation_ssm_install_subnet_chain
+        {
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!("\n\n\nSTEP: triggering delete SSM document for installing subnet in the region '{region}'\n")),
+                ResetColor
+            )?;
+            regional_cloudformation_manager
+                .delete_stack(ssm_doc_stack_name)
                 .await
                 .unwrap();
         }
     }
 
-    // delete no matter what, in case node provision failed
-    sleep(Duration::from_secs(1)).await;
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
-    execute!(
-        stdout(),
-        SetForegroundColor(Color::Red),
-        Print("\n\n\nSTEP: confirming delete ASG for non-anchor nodes\n"),
-        ResetColor
-    )?;
-    if let Some(stack_names) = &spec.resource.cloudformation_asg_non_anchor_nodes {
-        for stack_name in stack_names.iter() {
-            cloudformation_manager
+        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
+
+        // delete no matter what, in case node provision failed
+        sleep(Duration::from_secs(1)).await;
+        execute!(
+            stdout(),
+            SetForegroundColor(Color::Red),
+            Print(format!(
+                "\n\n\nSTEP: triggering delete ASG for non-anchor nodes in the region '{region}'\n"
+            )),
+            ResetColor
+        )?;
+        if let Some(stack_names) = &regional_resource.cloudformation_asg_non_anchor_nodes {
+            for stack_name in stack_names.iter() {
+                sleep(Duration::from_millis(200)).await;
+                regional_cloudformation_manager
+                    .delete_stack(stack_name)
+                    .await
+                    .unwrap();
+            }
+        }
+
+        execute!(
+            stdout(),
+            SetForegroundColor(Color::Red),
+            Print(format!(
+                "\n\n\nSTEP: triggering delete ASG for anchor nodes in the region '{region}'\n"
+            )),
+            ResetColor
+        )?;
+        if let Some(stack_names) = &regional_resource.cloudformation_asg_anchor_nodes {
+            for stack_name in stack_names.iter() {
+                sleep(Duration::from_millis(200)).await;
+                regional_cloudformation_manager
+                    .delete_stack(stack_name)
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+
+        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
+
+        // delete no matter what, in case node provision failed
+        sleep(Duration::from_secs(1)).await;
+        execute!(
+            stdout(),
+            SetForegroundColor(Color::Red),
+            Print(format!(
+                "\n\n\nSTEP: confirming delete ASG for non-anchor nodes in the region '{region}'\n"
+            )),
+            ResetColor
+        )?;
+        if let Some(stack_names) = &regional_resource.cloudformation_asg_non_anchor_nodes {
+            for stack_name in stack_names.iter() {
+                regional_cloudformation_manager
+                    .poll_stack(
+                        stack_name,
+                        StackStatus::DeleteComplete,
+                        Duration::from_secs(600),
+                        Duration::from_secs(30),
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+
+        execute!(
+            stdout(),
+            SetForegroundColor(Color::Red),
+            Print(format!(
+                "\n\n\nSTEP: confirming delete ASG for anchor nodes in the region '{region}'\n"
+            )),
+            ResetColor
+        )?;
+        if let Some(stack_names) = &regional_resource.cloudformation_asg_anchor_nodes {
+            for stack_name in stack_names {
+                regional_cloudformation_manager
+                    .poll_stack(
+                        stack_name,
+                        StackStatus::DeleteComplete,
+                        Duration::from_secs(600),
+                        Duration::from_secs(30),
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+
+        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
+
+        // VPC delete must run after associated EC2 instances are terminated due to dependencies
+        if regional_resource.cloudformation_vpc_id.is_some()
+            && regional_resource
+                .cloudformation_vpc_security_group_id
+                .is_some()
+            && regional_resource
+                .cloudformation_vpc_public_subnet_ids
+                .is_some()
+        {
+            sleep(Duration::from_secs(1)).await;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: deleting VPC in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
+            let vpc_stack_name = regional_resource.cloudformation_vpc.clone().unwrap();
+            regional_cloudformation_manager
+                .delete_stack(vpc_stack_name.as_str())
+                .await
+                .unwrap();
+            sleep(Duration::from_secs(10)).await;
+            regional_cloudformation_manager
                 .poll_stack(
-                    stack_name,
+                    vpc_stack_name.as_str(),
                     StackStatus::DeleteComplete,
-                    Duration::from_secs(600),
+                    Duration::from_secs(500),
                     Duration::from_secs(30),
                 )
                 .await
@@ -302,19 +406,35 @@ pub async fn execute(
         }
     }
 
-    execute!(
-        stdout(),
-        SetForegroundColor(Color::Red),
-        Print("\n\n\nSTEP: confirming delete ASG for anchor nodes\n"),
-        ResetColor
-    )?;
-    if let Some(stack_names) = spec.resource.cloudformation_asg_anchor_nodes {
-        for stack_name in stack_names.iter() {
-            cloudformation_manager
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+
+        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
+
+        if regional_resource
+            .cloudformation_ec2_instance_profile_arn
+            .is_some()
+        {
+            sleep(Duration::from_secs(1)).await;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: confirming delete EC2 instance role in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
+
+            let ec2_instance_role_stack_name = regional_resource
+                .cloudformation_ec2_instance_role
+                .clone()
+                .unwrap();
+            regional_cloudformation_manager
                 .poll_stack(
-                    stack_name,
+                    ec2_instance_role_stack_name.as_str(),
                     StackStatus::DeleteComplete,
-                    Duration::from_secs(600),
+                    Duration::from_secs(500),
                     Duration::from_secs(30),
                 )
                 .await
@@ -322,105 +442,69 @@ pub async fn execute(
         }
     }
 
-    // VPC delete must run after associated EC2 instances are terminated due to dependencies
-    if spec.resource.cloudformation_vpc_id.is_some()
-        && spec.resource.cloudformation_vpc_security_group_id.is_some()
-        && spec.resource.cloudformation_vpc_public_subnet_ids.is_some()
-    {
-        sleep(Duration::from_secs(1)).await;
+    for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+        let regional_shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: delete VPC\n"),
-            ResetColor
-        )?;
+        let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
-        let vpc_stack_name = spec.resource.cloudformation_vpc.unwrap();
-        cloudformation_manager
-            .delete_stack(vpc_stack_name.as_str())
-            .await
-            .unwrap();
-        sleep(Duration::from_secs(10)).await;
-        cloudformation_manager
-            .poll_stack(
-                vpc_stack_name.as_str(),
-                StackStatus::DeleteComplete,
-                Duration::from_secs(500),
-                Duration::from_secs(30),
-            )
-            .await
-            .unwrap();
-    }
+        if let Some(ssm_doc_stack_name) = &regional_resource.cloudformation_ssm_install_subnet_chain
+        {
+            sleep(Duration::from_secs(1)).await;
 
-    if spec
-        .resource
-        .cloudformation_ec2_instance_profile_arn
-        .is_some()
-    {
-        sleep(Duration::from_secs(1)).await;
-
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: confirming delete EC2 instance role\n"),
-            ResetColor
-        )?;
-
-        let ec2_instance_role_stack_name = spec.resource.cloudformation_ec2_instance_role.unwrap();
-        cloudformation_manager
-            .poll_stack(
-                ec2_instance_role_stack_name.as_str(),
-                StackStatus::DeleteComplete,
-                Duration::from_secs(500),
-                Duration::from_secs(30),
-            )
-            .await
-            .unwrap();
-    }
-
-    if let Some(ssm_doc_stack_name) = &spec.resource.cloudformation_ssm_install_subnet_chain {
-        sleep(Duration::from_secs(1)).await;
-
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: confirming delete SSM document for installing subnet\n"),
-            ResetColor
-        )?;
-        cloudformation_manager
-            .poll_stack(
-                ssm_doc_stack_name.as_str(),
-                StackStatus::DeleteComplete,
-                Duration::from_secs(500),
-                Duration::from_secs(30),
-            )
-            .await
-            .unwrap();
-    } else {
-        log::warn!("spec.resources.cloudformation_ssm_install_subnet_chain not found");
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!("\n\n\nSTEP: confirming delete SSM document for installing subnet in the region '{region}'\n")),
+                ResetColor
+            )?;
+            regional_cloudformation_manager
+                .poll_stack(
+                    ssm_doc_stack_name.as_str(),
+                    StackStatus::DeleteComplete,
+                    Duration::from_secs(500),
+                    Duration::from_secs(30),
+                )
+                .await
+                .unwrap();
+        } else {
+            log::warn!("regional_resource.cloudformation_ssm_install_subnet_chain not found");
+        }
     }
 
     if delete_cloudwatch_log_group {
-        // deletes the one auto-created by nodes
-        sleep(Duration::from_secs(1)).await;
+        for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+            let regional_shared_config =
+                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: cloudwatch log groups\n"),
-            ResetColor
-        )?;
-        cw_manager.delete_log_group(&spec.id).await.unwrap();
+            let regional_cloudwatch_manager = cloudwatch::Manager::new(&regional_shared_config);
+
+            // deletes the one auto-created by nodes
+            sleep(Duration::from_secs(1)).await;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: deleting cloudwatch log groups in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
+            regional_cloudwatch_manager
+                .delete_log_group(&spec.id)
+                .await
+                .unwrap();
+        }
     }
 
     if delete_s3_objects {
         sleep(Duration::from_secs(1)).await;
-
         execute!(
             stdout(),
             SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: delete S3 objects\n"),
+            Print(format!(
+                "\n\n\nSTEP: deleting S3 objects in the region '{}'\n",
+                spec.resource.regions[0]
+            )),
             ResetColor
         )?;
         sleep(Duration::from_secs(5)).await;
@@ -432,11 +516,13 @@ pub async fn execute(
 
     if delete_s3_bucket {
         sleep(Duration::from_secs(1)).await;
-
         execute!(
             stdout(),
             SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: delete S3 bucket\n"),
+            Print(format!(
+                "\n\n\nSTEP: deleting S3 bucket in the region '{}'\n",
+                spec.resource.regions[0]
+            )),
             ResetColor
         )?;
         sleep(Duration::from_secs(5)).await;
@@ -447,70 +533,90 @@ pub async fn execute(
     }
 
     if delete_ebs_volumes {
-        sleep(Duration::from_secs(1)).await;
+        for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+            let regional_shared_config =
+                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: deleting orphaned EBS volumes\n"),
-            ResetColor
-        )?;
-        // ref. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html
-        let filters: Vec<Filter> = vec![
-            Filter::builder()
-                .set_name(Some(String::from("tag:Kind")))
-                .set_values(Some(vec![String::from("aws-volume-provisioner")]))
-                .build(),
-            Filter::builder()
-                .set_name(Some(String::from("tag:Id")))
-                .set_values(Some(vec![spec.id.clone()]))
-                .build(),
-        ];
-        let volumes = ec2_manager.describe_volumes(Some(filters)).await.unwrap();
-        log::info!("found {} volumes", volumes.len());
-        if !volumes.is_empty() {
-            log::info!("deleting {} volumes", volumes.len());
-            for v in volumes {
-                let volume_id = v.volume_id().unwrap().to_string();
-                log::info!("deleting EBS volume '{}'", volume_id);
-                ec2_manager
-                    .cli
-                    .delete_volume()
-                    .volume_id(volume_id)
-                    .send()
-                    .await
-                    .unwrap();
-                sleep(Duration::from_secs(1)).await;
+            let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
+
+            sleep(Duration::from_secs(1)).await;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: deleting orphaned EBS volumes in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
+            // ref. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html
+            let filters: Vec<Filter> = vec![
+                Filter::builder()
+                    .set_name(Some(String::from("tag:Kind")))
+                    .set_values(Some(vec![String::from("aws-volume-provisioner")]))
+                    .build(),
+                Filter::builder()
+                    .set_name(Some(String::from("tag:Id")))
+                    .set_values(Some(vec![spec.id.clone()]))
+                    .build(),
+            ];
+            let volumes = regional_ec2_manager
+                .describe_volumes(Some(filters))
+                .await
+                .unwrap();
+            log::info!("found {} volumes", volumes.len());
+            if !volumes.is_empty() {
+                log::info!("deleting {} volumes", volumes.len());
+                for v in volumes {
+                    let volume_id = v.volume_id().unwrap().to_string();
+                    log::info!("deleting EBS volume '{}'", volume_id);
+                    regional_ec2_manager
+                        .cli
+                        .delete_volume()
+                        .volume_id(volume_id)
+                        .send()
+                        .await
+                        .unwrap();
+                    sleep(Duration::from_secs(1)).await;
+                }
             }
         }
     }
 
     if delete_elastic_ips {
-        sleep(Duration::from_secs(1)).await;
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Red),
-            Print("\n\n\nSTEP: releasing orphaned elastic IPs\n"),
-            ResetColor
-        )?;
-        let eips = ec2_manager
-            .describe_eips_by_tags(HashMap::from([(String::from("Id"), spec.id.clone())]))
-            .await
-            .unwrap();
-        log::info!("found {} elastic IP addresses", eips.len());
-        for eip_addr in eips.iter() {
-            let allocation_id = eip_addr.allocation_id.to_owned().unwrap();
+        for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
+            let regional_shared_config =
+                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
 
-            log::info!("releasing elastic IP via allocation Id {}", allocation_id);
+            let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
-            ec2_manager
-                .cli
-                .release_address()
-                .allocation_id(allocation_id)
-                .send()
+            sleep(Duration::from_secs(1)).await;
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Red),
+                Print(format!(
+                    "\n\n\nSTEP: releasing orphaned elastic IPs in the region '{region}'\n"
+                )),
+                ResetColor
+            )?;
+            let eips = regional_ec2_manager
+                .describe_eips_by_tags(HashMap::from([(String::from("Id"), spec.id.clone())]))
                 .await
                 .unwrap();
-            sleep(Duration::from_secs(2)).await;
+            log::info!("found {} elastic IP addresses", eips.len());
+            for eip_addr in eips.iter() {
+                let allocation_id = eip_addr.allocation_id.to_owned().unwrap();
+
+                log::info!("releasing elastic IP via allocation Id {}", allocation_id);
+
+                regional_ec2_manager
+                    .cli
+                    .release_address()
+                    .allocation_id(allocation_id)
+                    .send()
+                    .await
+                    .unwrap();
+                sleep(Duration::from_secs(2)).await;
+            }
         }
     }
 

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -283,8 +283,14 @@ pub async fn execute(
             ResetColor
         )?;
         if let Some(stack_names) = &regional_resource.cloudformation_asg_non_anchor_nodes {
+            let interval = if stack_names.len() > 20 {
+                Duration::from_secs(1)
+            } else {
+                Duration::from_millis(200)
+            };
             for stack_name in stack_names.iter() {
-                sleep(Duration::from_millis(200)).await;
+                sleep(interval).await;
+
                 regional_cloudformation_manager
                     .delete_stack(stack_name)
                     .await
@@ -301,8 +307,14 @@ pub async fn execute(
             ResetColor
         )?;
         if let Some(stack_names) = &regional_resource.cloudformation_asg_anchor_nodes {
+            let interval = if stack_names.len() > 20 {
+                Duration::from_secs(1)
+            } else {
+                Duration::from_millis(200)
+            };
             for stack_name in stack_names.iter() {
-                sleep(Duration::from_millis(200)).await;
+                sleep(interval).await;
+
                 regional_cloudformation_manager
                     .delete_stack(stack_name)
                     .await

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -847,6 +847,9 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             opts.subnet_validate_period_in_days
         );
 
+        // TODO: remove this... after fixing flaky errors of utxo not found
+        sleep(Duration::from_secs(2)).await;
+
         // randomly wait to prevnt UTXO double spends from the same wallet
         let random_wait = if i < 5 {
             Duration::from_secs(2 + (i * 2) as u64)
@@ -857,7 +860,6 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
                 .checked_add(Duration::from_millis(500 + random_manager::u64() % 100))
                 .unwrap()
         };
-
         handles.push(tokio::spawn(add_subnet_network_validator(
             Arc::new(random_wait),
             Arc::new(wallet_to_spend.clone()),

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -659,7 +659,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     let mut handles = Vec::new();
     for (i, (node_id, region_machine_id)) in target_nodes.iter().enumerate() {
         // randomly wait to prevent UTXO double spends from the same wallet
-        let random_wait = Duration::from_secs(1 + i as u64)
+        let random_wait = Duration::from_secs(1 + (i + 1) as u64)
             .checked_add(Duration::from_millis(500 + random_manager::u64() % 100))
             .unwrap();
 
@@ -847,10 +847,16 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             opts.subnet_validate_period_in_days
         );
 
-        // randomly wait to prevent UTXO double spends from the same wallet
-        let random_wait = Duration::from_secs(1 + i as u64)
-            .checked_add(Duration::from_millis(500 + random_manager::u64() % 100))
-            .unwrap();
+        // randomly wait to prevnt UTXO double spends from the same wallet
+        let random_wait = if i < 5 {
+            Duration::from_secs(2 + (i * 2) as u64)
+                .checked_add(Duration::from_millis(500 + random_manager::u64() % 100))
+                .unwrap()
+        } else {
+            Duration::from_secs(5 + (i * 2) as u64)
+                .checked_add(Duration::from_millis(500 + random_manager::u64() % 100))
+                .unwrap()
+        };
 
         handles.push(tokio::spawn(add_subnet_network_validator(
             Arc::new(random_wait),

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -33,10 +33,9 @@ pub struct Flags {
     pub skip_prompt: bool,
     pub spec_file_path: String,
 
-    pub region: String,
+    pub s3_region: String,
     pub s3_bucket: String,
     pub s3_key_prefix: String,
-    pub ssm_doc: String,
 
     pub chain_rpc_url: String,
     pub key: String,
@@ -59,13 +58,14 @@ pub struct Flags {
 
     pub avalanchego_config_remote_path: String,
 
-    pub node_ids_to_instance_ids: HashMap<String, String>,
+    pub ssm_docs: HashMap<String, String>,
+    pub target_nodes: HashMap<String, avalanche_ops::aws::spec::RegionMachineId>,
 }
 
 #[derive(Clone, Debug)]
-pub struct HashMapParser;
+pub struct HashMapStringToStringParser;
 
-impl clap::builder::TypedValueParser for HashMapParser {
+impl clap::builder::TypedValueParser for HashMapStringToStringParser {
     type Value = HashMap<String, String>;
 
     fn parse_ref(
@@ -81,6 +81,30 @@ impl clap::builder::TypedValueParser for HashMapParser {
                 format!("HashMap parsing failed ({})", e),
             )
         })?;
+        Ok(m)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HashMapStringToRegionInstanceIdParser;
+
+impl clap::builder::TypedValueParser for HashMapStringToRegionInstanceIdParser {
+    type Value = HashMap<String, avalanche_ops::aws::spec::RegionMachineId>;
+
+    fn parse_ref(
+        &self,
+        _cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let str = value.to_str().unwrap_or_default();
+        let m: HashMap<String, avalanche_ops::aws::spec::RegionMachineId> =
+            serde_json::from_str(str).map_err(|e| {
+                clap::Error::raw(
+                    clap::error::ErrorKind::InvalidValue,
+                    format!("HashMap parsing failed ({})", e),
+                )
+            })?;
         Ok(m)
     }
 }
@@ -115,9 +139,9 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .help("Sets the AWS region for API calls/endpoints")
+            Arg::new("S3_REGION")
+                .long("s3-region")
+                .help("Sets the AWS S3 region")
                 .required(true)
                 .num_args(1)
                 .default_value("us-west-2"),
@@ -133,13 +157,6 @@ pub fn command() -> Command {
             Arg::new("S3_KEY_PREFIX")
                 .long("s3-key-prefix")
                 .help("Sets the S3 key prefix for all artifacts")
-                .required(true)
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("SSM_DOC")
-                .long("ssm-doc")
-                .help("Sets the SSM document name for subnet and chain install (see avalanche-ops/src/aws/cfn-templates/ssm_install_subnet_chain.yaml)")
                 .required(true)
                 .num_args(1),
         )
@@ -280,11 +297,19 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
-            Arg::new("NODE_IDS_TO_INSTANCE_IDS")
-                .long("node-ids-to-instance-ids")
-                .help("Sets the hash map of node Id to instance Id in JSON format")
+            Arg::new("SSM_DOCS")
+                .long("ssm-docs")
+                .help("Sets the hash map of AWS region to SSM document name for subnet and chain install (see avalanche-ops/src/aws/cfn-templates/ssm_install_subnet_chain.yaml)")
+                .required(true)
+                .value_parser(HashMapStringToStringParser {})
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("TARGET_NODES")
+                .long("target-nodes")
+                .help("Sets the hash map of node Id to the corresponding EC2 region, and instance Id in JSON format")
                 .required(false)
-                .value_parser(HashMapParser {})
+                .value_parser(HashMapStringToRegionInstanceIdParser {})
                 .num_args(1),
         )
 }
@@ -296,7 +321,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     );
 
     let mut node_id_to_pop = HashMap::new();
-    let mut node_ids_to_instance_ids = HashMap::new();
+    let mut target_nodes = HashMap::new();
     if !opts.spec_file_path.is_empty() {
         let spec = avalanche_ops::aws::spec::Spec::load(&opts.spec_file_path)
             .expect("failed to load spec");
@@ -305,11 +330,17 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             for node in created_nodes {
                 let node_id = ids::node::Id::from_str(&node.node_id).unwrap();
                 node_id_to_pop.insert(node_id, node.proof_of_possession.clone());
-                node_ids_to_instance_ids.insert(node.node_id.clone(), node.machine_id.clone());
+                target_nodes.insert(
+                    node.node_id.clone(),
+                    avalanche_ops::aws::spec::RegionMachineId {
+                        region: node.region.clone(),
+                        machine_id: node.machine_id.clone(),
+                    },
+                );
             }
         }
     } else {
-        node_ids_to_instance_ids = opts.node_ids_to_instance_ids.clone();
+        target_nodes = opts.target_nodes.clone();
     }
 
     if !Path::new(&opts.vm_binary_local_path).exists() {
@@ -378,10 +409,23 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
 
     let mut all_node_ids = Vec::new();
     let mut all_instance_ids = Vec::new();
-    for (node_id, instance_id) in node_ids_to_instance_ids.iter() {
-        log::info!("will send SSM doc to {node_id} {instance_id}");
+    let mut region_to_instance_ids: HashMap<String, Vec<String>> = HashMap::new();
+    for (node_id, region_machine_id) in target_nodes.iter() {
+        log::info!(
+            "will send SSM doc to {node_id} {}",
+            region_machine_id.machine_id
+        );
         all_node_ids.push(node_id.clone());
-        all_instance_ids.push(instance_id.clone());
+        all_instance_ids.push(region_machine_id.machine_id.clone());
+
+        if let Some(instance_ids) = region_to_instance_ids.get_mut(&region_machine_id.region) {
+            instance_ids.push(region_machine_id.machine_id.clone());
+        } else {
+            region_to_instance_ids.insert(
+                region_machine_id.region.clone(),
+                vec![region_machine_id.machine_id.clone()],
+            );
+        }
     }
 
     // if all nodes need to be staked
@@ -428,16 +472,15 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             opts.primary_network_validate_period_in_days,
             opts.subnet_validate_period_in_days,
             opts.staking_amount_in_avax,
-            node_ids_to_instance_ids,
+            target_nodes,
         )),
         ResetColor
     )?;
 
     let shared_config =
-        aws_manager::load_config(Some(opts.region.clone()), Some(Duration::from_secs(30))).await;
+        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
     let sts_manager = sts::Manager::new(&shared_config);
     let s3_manager = s3::Manager::new(&shared_config);
-    let ssm_manager = ssm::Manager::new(&shared_config);
 
     let current_identity = sts_manager.get_identity().await.unwrap();
     log::info!("current AWS identity: {:?}", current_identity);
@@ -600,7 +643,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
             .as_u64();
 
     let mut handles = Vec::new();
-    for (i, (node_id, instance_id)) in node_ids_to_instance_ids.iter().enumerate() {
+    for (i, (node_id, region_machine_id)) in target_nodes.iter().enumerate() {
         // randomly wait to prevent UTXO double spends from the same wallet
         let random_wait = Duration::from_secs(1 + i as u64)
             .checked_add(Duration::from_millis(500 + random_manager::u64() % 100))
@@ -609,7 +652,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         log::info!(
             "spawning add_primary_network_permissionless_validator/add_primary_network_validator on '{}' (of EC2 instance '{}', staking period in days '{}')",
             node_id,
-            instance_id,
+            region_machine_id.machine_id,
             opts.primary_network_validate_period_in_days,
         );
         let node_id = ids::node::Id::from_str(node_id).unwrap();
@@ -683,8 +726,8 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         Print("\n\n\nSTEP: send SSM doc to download Vm binary, track subnet Id, update subnet config\n\n"),
         ResetColor
     )?;
-    let subcmd = format!("install-subnet --log-level info --region {region} --s3-bucket {s3_bucket} --vm-binary-s3-key {vm_binary_s3_key} --vm-binary-local-path {vm_binary_local_path} --subnet-id-to-track {subnet_id_to_track} --avalanchego-config-path {avalanchego_config_remote_path}",
-        region = opts.region,
+    let subcmd = format!("install-subnet --log-level info --s3-region {region} --s3-bucket {s3_bucket} --vm-binary-s3-key {vm_binary_s3_key} --vm-binary-local-path {vm_binary_local_path} --subnet-id-to-track {subnet_id_to_track} --avalanchego-config-path {avalanchego_config_remote_path}",
+        region = opts.s3_region,
         s3_bucket = opts.s3_bucket,
         vm_binary_s3_key = vm_binary_s3_key,
         vm_binary_local_path = format!("{}{}", s3::append_slash(&opts.vm_binary_remote_dir), vm_id.to_string()),
@@ -710,47 +753,66 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     } else {
         subcmd
     };
-    // ref. <https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html>
-    let ssm_output = ssm_manager
-        .cli
-        .send_command()
-        .document_name(opts.ssm_doc.clone())
-        .set_instance_ids(Some(all_instance_ids.clone()))
-        .parameters("avalanchedArgs", vec![avalanched_args.clone()])
-        .output_s3_region(opts.region.clone())
-        .output_s3_bucket_name(opts.s3_bucket.clone())
-        .output_s3_key_prefix(format!(
-            "{}ssm-output-logs",
-            s3::append_slash(&opts.s3_key_prefix)
-        ))
-        .send()
-        .await
-        .unwrap();
-    let ssm_output = ssm_output.command().unwrap();
-    let ssm_command_id = ssm_output.command_id().unwrap();
-    log::info!("sent SSM command {}", ssm_command_id);
-    sleep(Duration::from_secs(30)).await;
 
-    execute!(
-        stdout(),
-        SetForegroundColor(Color::Green),
-        Print("\n\n\nSTEP: checking the status of SSM command...\n\n"),
-        ResetColor
-    )?;
-    for instance_id in all_instance_ids.iter() {
-        let status = ssm_manager
-            .poll_command(
-                ssm_command_id,
-                instance_id,
-                CommandInvocationStatus::Success,
-                Duration::from_secs(300),
-                Duration::from_secs(5),
-            )
+    for (region, instance_ids) in region_to_instance_ids.iter() {
+        if !opts.ssm_docs.contains_key(region) {
+            panic!(
+                "--ssm-docs does not have the document name for the region '{}'",
+                region
+            );
+        }
+        let ssm_doc = opts.ssm_docs.get(region).unwrap();
+
+        log::info!(
+            "sending SSM commands for the region '{region}' with instances {:?}",
+            instance_ids
+        );
+        let shared_config =
+            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let ssm_manager = ssm::Manager::new(&shared_config);
+
+        // ref. <https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html>
+        let ssm_output = ssm_manager
+            .cli
+            .send_command()
+            .document_name(ssm_doc.clone())
+            .set_instance_ids(Some(instance_ids.clone()))
+            .parameters("avalanchedArgs", vec![avalanched_args.clone()])
+            .output_s3_region(opts.s3_region.clone())
+            .output_s3_bucket_name(opts.s3_bucket.clone())
+            .output_s3_key_prefix(format!(
+                "{}ssm-output-logs",
+                s3::append_slash(&opts.s3_key_prefix)
+            ))
+            .send()
             .await
             .unwrap();
-        log::info!("status {:?} for instance id {}", status, instance_id);
+        let ssm_output = ssm_output.command().unwrap();
+        let ssm_command_id = ssm_output.command_id().unwrap();
+        log::info!("sent SSM command {}", ssm_command_id);
+        sleep(Duration::from_secs(30)).await;
+
+        execute!(
+            stdout(),
+            SetForegroundColor(Color::Green),
+            Print("\n\n\nSTEP: checking the status of SSM command...\n\n"),
+            ResetColor
+        )?;
+        for instance_id in instance_ids.iter() {
+            let status = ssm_manager
+                .poll_command(
+                    ssm_command_id,
+                    instance_id,
+                    CommandInvocationStatus::Success,
+                    Duration::from_secs(300),
+                    Duration::from_secs(5),
+                )
+                .await
+                .unwrap();
+            log::info!("status {:?} for instance id {}", status, instance_id);
+        }
+        sleep(Duration::from_secs(5)).await;
     }
-    sleep(Duration::from_secs(5)).await;
 
     //
     //
@@ -851,54 +913,72 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
 
         // If a Subnet's chain id is 2ebCneCbwthjQ1rYT41nhd7M76Hc6YmosMAQrTFhBq8qeqh6tt,
         // the config file for this chain is located at {chain-config-dir}/2ebCneCbwthjQ1rYT41nhd7M76Hc6YmosMAQrTFhBq8qeqh6tt/config.json.
-        let avalanched_args = format!("install-chain --log-level info --region {region} --s3-bucket {s3_bucket} --chain-config-s3-key {chain_config_s3_key} --chain-config-local-path {chain_config_local_path}",
-            region = opts.region,
+        let avalanched_args = format!("install-chain --log-level info --s3-region {region} --s3-bucket {s3_bucket} --chain-config-s3-key {chain_config_s3_key} --chain-config-local-path {chain_config_local_path}",
+            region = opts.s3_region,
             s3_bucket = opts.s3_bucket,
             chain_config_s3_key = chain_config_s3_key,
             chain_config_local_path = format!("{}{}/config.json", s3::append_slash(&opts.chain_config_remote_dir), blockchain_id.to_string()),
         );
 
-        // ref. <https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html>
-        let ssm_output = ssm_manager
-            .cli
-            .send_command()
-            .document_name(opts.ssm_doc.clone())
-            .set_instance_ids(Some(all_instance_ids.clone()))
-            .parameters("avalanchedArgs", vec![avalanched_args.clone()])
-            .output_s3_region(opts.region.clone())
-            .output_s3_bucket_name(opts.s3_bucket.clone())
-            .output_s3_key_prefix(format!(
-                "{}ssm-output-logs",
-                s3::append_slash(&opts.s3_key_prefix)
-            ))
-            .send()
-            .await
-            .unwrap();
-        let ssm_output = ssm_output.command().unwrap();
-        let ssm_command_id = ssm_output.command_id().unwrap();
-        log::info!("sent SSM command {}", ssm_command_id);
-        sleep(Duration::from_secs(30)).await;
+        for (region, instance_ids) in region_to_instance_ids.iter() {
+            if !opts.ssm_docs.contains_key(region) {
+                panic!(
+                    "--ssm-docs does not have the document name for the region '{}'",
+                    region
+                );
+            }
+            let ssm_doc = opts.ssm_docs.get(region).unwrap();
 
-        execute!(
-            stdout(),
-            SetForegroundColor(Color::Green),
-            Print("\n\n\nSTEP: checking the status of SSM command...\n\n"),
-            ResetColor
-        )?;
-        for instance_id in all_instance_ids.iter() {
-            let status = ssm_manager
-                .poll_command(
-                    ssm_command_id,
-                    instance_id,
-                    CommandInvocationStatus::Success,
-                    Duration::from_secs(300),
-                    Duration::from_secs(5),
-                )
+            log::info!(
+                "sending SSM commands for the region '{region}' with instances {:?}",
+                instance_ids
+            );
+            let shared_config =
+                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let ssm_manager = ssm::Manager::new(&shared_config);
+
+            // ref. <https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html>
+            let ssm_output = ssm_manager
+                .cli
+                .send_command()
+                .document_name(ssm_doc.clone())
+                .set_instance_ids(Some(instance_ids.clone()))
+                .parameters("avalanchedArgs", vec![avalanched_args.clone()])
+                .output_s3_region(opts.s3_region.clone())
+                .output_s3_bucket_name(opts.s3_bucket.clone())
+                .output_s3_key_prefix(format!(
+                    "{}ssm-output-logs",
+                    s3::append_slash(&opts.s3_key_prefix)
+                ))
+                .send()
                 .await
                 .unwrap();
-            log::info!("status {:?} for instance id {}", status, instance_id);
+            let ssm_output = ssm_output.command().unwrap();
+            let ssm_command_id = ssm_output.command_id().unwrap();
+            log::info!("sent SSM command {}", ssm_command_id);
+            sleep(Duration::from_secs(30)).await;
+
+            execute!(
+                stdout(),
+                SetForegroundColor(Color::Green),
+                Print("\n\n\nSTEP: checking the status of SSM command...\n\n"),
+                ResetColor
+            )?;
+            for instance_id in all_instance_ids.iter() {
+                let status = ssm_manager
+                    .poll_command(
+                        ssm_command_id,
+                        instance_id,
+                        CommandInvocationStatus::Success,
+                        Duration::from_secs(300),
+                        Duration::from_secs(5),
+                    )
+                    .await
+                    .unwrap();
+                log::info!("status {:?} for instance id {}", status, instance_id);
+            }
+            sleep(Duration::from_secs(5)).await;
         }
-        sleep(Duration::from_secs(5)).await;
     }
 
     println!();

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -326,7 +326,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         let spec = avalanche_ops::aws::spec::Spec::load(&opts.spec_file_path)
             .expect("failed to load spec");
         spec.validate()?;
-        if let Some(created_nodes) = &spec.resources.created_nodes {
+        if let Some(created_nodes) = &spec.resource.created_nodes {
             for node in created_nodes {
                 let node_id = ids::node::Id::from_str(&node.node_id).unwrap();
                 node_id_to_pop.insert(node_id, node.proof_of_possession.clone());

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -344,7 +344,7 @@ async fn main() -> io::Result<()> {
                     .unwrap_or(&String::new())
                     .clone(),
 
-                s3_region: sub_matches.get_one::<String>("REGION").unwrap().clone(),
+                s3_region: sub_matches.get_one::<String>("S3_REGION").unwrap().clone(),
                 s3_bucket: sub_matches.get_one::<String>("S3_BUCKET").unwrap().clone(),
                 s3_key_prefix: sub_matches
                     .get_one::<String>("S3_KEY_PREFIX")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -47,18 +47,15 @@ async fn main() -> io::Result<()> {
                 }
             }
 
-            let s = sub_matches
-                .get_one::<String>("INSTANCE_TYPES")
-                .unwrap_or(&String::new())
+            let instance_types: HashMap<String, Vec<String>> = sub_matches
+                .get_one::<HashMap<String, Vec<String>>>("INSTANCE_TYPES")
+                .unwrap_or(&HashMap::new())
                 .clone();
-            let ss: Vec<&str> = s.split(',').collect();
-            let mut instance_types = Vec::new();
-            for addr in ss.iter() {
-                let trimmed = addr.trim().to_string();
-                if !trimmed.is_empty() {
-                    instance_types.push(addr.trim().to_string());
-                }
-            }
+
+            let nlb_acm_certificate_arns: HashMap<String, String> = sub_matches
+                .get_one::<HashMap<String, String>>("NLB_ACM_CERTIFICATE_ARNS")
+                .unwrap_or(&HashMap::new())
+                .clone();
 
             let s = sub_matches
                 .get_one::<String>("REGIONS")
@@ -156,10 +153,7 @@ async fn main() -> io::Result<()> {
                     .unwrap()
                     .to_string(),
 
-                nlb_acm_certificate_arn: sub_matches
-                    .get_one::<String>("NLB_ACM_CERTIFICATE_ARN")
-                    .unwrap_or(&String::new())
-                    .to_string(),
+                nlb_acm_certificate_arns,
 
                 upload_artifacts_aws_volume_provisioner_local_bin: sub_matches
                     .get_one::<String>("UPLOAD_ARTIFACTS_AWS_VOLUME_PROVISIONER_LOCAL_BIN")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -111,6 +111,10 @@ async fn main() -> io::Result<()> {
                     .clone(),
 
                 regions,
+                auto_regions: sub_matches
+                    .get_one::<usize>("AUTO_REGIONS")
+                    .unwrap_or(&0)
+                    .clone(),
                 ingress_ipv4_cidr: sub_matches
                     .get_one::<String>("INGRESS_IPV4_CIDR")
                     .unwrap_or(&String::new())

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> io::Result<()> {
 
                 regions,
                 auto_regions: sub_matches
-                    .get_one::<usize>("AUTO_REGIONS")
+                    .get_one::<u32>("AUTO_REGIONS")
                     .unwrap_or(&0)
                     .clone(),
                 ingress_ipv4_cidr: sub_matches

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzard-aws"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
@@ -9,8 +9,8 @@ name = "blizzard-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.368", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.15", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.369", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.16", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -9,8 +9,8 @@ name = "blizzard-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.369", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.16", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.370", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.17", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzard-aws/src/command.rs
+++ b/blizzard-aws/src/command.rs
@@ -210,10 +210,13 @@ async fn download_spec(
     let tmp_spec_file_path = random_manager::tmp_path(15, Some(".yaml"))?;
 
     let exists = s3_manager
-        .get_object(
+        .get_object_with_retries(
             s3_bucket,
             &blizzardup_aws::StorageNamespace::ConfigFile(id.to_string()).encode(),
             &tmp_spec_file_path,
+            true,
+            Duration::from_secs(30),
+            Duration::from_secs(1),
         )
         .await
         .map_err(|e| Error::new(ErrorKind::Other, format!("failed spawn_get_object {}", e)))?;

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzardup-aws"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
@@ -9,8 +9,8 @@ name = "blizzardup-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.368", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.15", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.369", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.16", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -9,8 +9,8 @@ name = "blizzardup-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.369", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.16", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.370", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.17", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.26.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 rust-version = "1.69"
 
 [dependencies]
-avalanche-types = { version = "0.0.369", features = ["cert"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.16", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.370", features = ["cert"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.17", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.4", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "staking-key-cert-s3-downloader"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
 [dependencies]
-avalanche-types = { version = "0.0.368", features = ["cert"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.26.15", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.369", features = ["cert"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.26.16", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.4", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/staking-key-cert-s3-downloader/src/command.rs
+++ b/staking-key-cert-s3-downloader/src/command.rs
@@ -20,10 +20,14 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, opts.log_level),
     );
 
-    let shared_config =
-        aws_manager::load_config(Some(opts.region.clone()), Some(Duration::from_secs(30))).await;
-    let kms_manager = kms::Manager::new(&shared_config);
-    let s3_manager = s3::Manager::new(&shared_config);
+    let s3_shared_config =
+        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
+    let s3_manager = s3::Manager::new(&s3_shared_config);
+
+    let kms_shared_config =
+        aws_manager::load_config(Some(opts.kms_region.clone()), Some(Duration::from_secs(30)))
+            .await;
+    let kms_manager = kms::Manager::new(&kms_shared_config);
 
     let envelope_manager = envelope::Manager::new(
         &kms_manager,

--- a/staking-key-cert-s3-downloader/src/command.rs
+++ b/staking-key-cert-s3-downloader/src/command.rs
@@ -64,6 +64,7 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
             &opts.s3_bucket,
             &opts.s3_key_tls_key,
             &opts.tls_key_path,
+            false,
         )
         .await
         .map_err(|e| {
@@ -80,6 +81,7 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
             &opts.s3_bucket,
             &opts.s3_key_tls_cert,
             &opts.tls_cert_path,
+            false,
         )
         .await
         .map_err(|e| {

--- a/staking-key-cert-s3-downloader/src/flags.rs
+++ b/staking-key-cert-s3-downloader/src/flags.rs
@@ -2,10 +2,11 @@
 #[derive(Debug)]
 pub struct Options {
     pub log_level: String,
-    pub region: String,
+    pub s3_region: String,
     pub s3_bucket: String,
     pub s3_key_tls_key: String,
     pub s3_key_tls_cert: String,
+    pub kms_region: String,
     pub kms_key_id: String,
     pub aad_tag: String,
     pub tls_key_path: String,

--- a/staking-key-cert-s3-downloader/src/main.rs
+++ b/staking-key-cert-s3-downloader/src/main.rs
@@ -39,9 +39,9 @@ staking-key-cert-s3-downloader \
                 .default_value("info"),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .help("Sets the AWS region")
+            Arg::new("S3_REGION")
+                .long("s3-region")
+                .help("Sets the AWS S3 region")
                 .required(true)
                 .num_args(1),
         )
@@ -63,6 +63,13 @@ staking-key-cert-s3-downloader \
             Arg::new("S3_KEY_TLS_CERT")
                 .long("s3-key-tls-cert")
                 .help("Sets the S3 key for TLS cert")
+                .required(true)
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("KMS_REGION")
+                .long("kms-region")
+                .help("Sets the AWS KMS region")
                 .required(true)
                 .num_args(1),
         )
@@ -101,13 +108,14 @@ staking-key-cert-s3-downloader \
             .get_one::<String>("LOG_LEVEL")
             .unwrap_or(&String::from("info"))
             .clone(),
-        region: matches.get_one::<String>("REGION").unwrap().clone(),
+        s3_region: matches.get_one::<String>("S3_REGION").unwrap().clone(),
         s3_bucket: matches.get_one::<String>("S3_BUCKET").unwrap().clone(),
         s3_key_tls_key: matches.get_one::<String>("S3_KEY_TLS_KEY").unwrap().clone(),
         s3_key_tls_cert: matches
             .get_one::<String>("S3_KEY_TLS_CERT")
             .unwrap()
             .clone(),
+        kms_region: matches.get_one::<String>("KMS_REGION").unwrap().clone(),
         kms_key_id: matches.get_one::<String>("KMS_KEY_ID").unwrap().clone(),
         aad_tag: matches.get_one::<String>("AAD_TAG").unwrap().clone(),
         tls_key_path: matches.get_one::<String>("TLS_KEY_PATH").unwrap().clone(),

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "staking-signer-key-s3-downloader"
-version = "0.4.2" # https://github.com/ava-labs/avalanche-ops/releases
+version = "0.5.0-alpha.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.69"
 
 [dependencies]
-aws-manager = { version = "0.26.15", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.26.16", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.4", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.69"
 
 [dependencies]
-aws-manager = { version = "0.26.16", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.26.17", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.2.4", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/staking-signer-key-s3-downloader/src/command.rs
+++ b/staking-signer-key-s3-downloader/src/command.rs
@@ -19,10 +19,14 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, opts.log_level),
     );
 
-    let shared_config =
-        aws_manager::load_config(Some(opts.region.clone()), Some(Duration::from_secs(30))).await;
-    let kms_manager = kms::Manager::new(&shared_config);
-    let s3_manager = s3::Manager::new(&shared_config);
+    let s3_shared_config =
+        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
+    let s3_manager = s3::Manager::new(&s3_shared_config);
+
+    let kms_shared_config =
+        aws_manager::load_config(Some(opts.kms_region.clone()), Some(Duration::from_secs(30)))
+            .await;
+    let kms_manager = kms::Manager::new(&kms_shared_config);
 
     let envelope_manager = envelope::Manager::new(
         &kms_manager,

--- a/staking-signer-key-s3-downloader/src/command.rs
+++ b/staking-signer-key-s3-downloader/src/command.rs
@@ -37,7 +37,13 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
 
     log::info!("downloading key file {}", opts.key_path);
     envelope_manager
-        .get_object_unseal_decompress(&s3_manager, &opts.s3_bucket, &opts.s3_key, &opts.key_path)
+        .get_object_unseal_decompress(
+            &s3_manager,
+            &opts.s3_bucket,
+            &opts.s3_key,
+            &opts.key_path,
+            false,
+        )
         .await
         .map_err(|e| {
             Error::new(

--- a/staking-signer-key-s3-downloader/src/flags.rs
+++ b/staking-signer-key-s3-downloader/src/flags.rs
@@ -2,9 +2,10 @@
 #[derive(Debug)]
 pub struct Options {
     pub log_level: String,
-    pub region: String,
+    pub s3_region: String,
     pub s3_bucket: String,
     pub s3_key: String,
+    pub kms_region: String,
     pub kms_key_id: String,
     pub aad_tag: String,
     pub key_path: String,

--- a/staking-signer-key-s3-downloader/src/main.rs
+++ b/staking-signer-key-s3-downloader/src/main.rs
@@ -37,9 +37,9 @@ staking-signer-key-s3-downloader \
                 .default_value("info"),
         )
         .arg(
-            Arg::new("REGION")
-                .long("region")
-                .help("Sets the AWS region")
+            Arg::new("S3_REGION")
+                .long("s3-region")
+                .help("Sets the AWS S3 region")
                 .required(true)
                 .num_args(1),
         )
@@ -54,6 +54,13 @@ staking-signer-key-s3-downloader \
             Arg::new("S3_KEY")
                 .long("s3-key")
                 .help("Sets the S3 key")
+                .required(true)
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("KMS_REGION")
+                .long("kms-region")
+                .help("Sets the AWS KMS region")
                 .required(true)
                 .num_args(1),
         )
@@ -85,9 +92,10 @@ staking-signer-key-s3-downloader \
             .get_one::<String>("LOG_LEVEL")
             .unwrap_or(&String::from("info"))
             .clone(),
-        region: matches.get_one::<String>("REGION").unwrap().clone(),
+        s3_region: matches.get_one::<String>("S3_REGION").unwrap().clone(),
         s3_bucket: matches.get_one::<String>("S3_BUCKET").unwrap().clone(),
         s3_key: matches.get_one::<String>("S3_KEY").unwrap().clone(),
+        kms_region: matches.get_one::<String>("KMS_REGION").unwrap().clone(),
         kms_key_id: matches.get_one::<String>("KMS_KEY_ID").unwrap().clone(),
         aad_tag: matches.get_one::<String>("AAD_TAG").unwrap().clone(),
         key_path: matches.get_one::<String>("KEY_PATH").unwrap().clone(),


### PR DESCRIPTION
Fix https://github.com/ava-labs/avalanche-ops/issues/310.

---

### Before

```bash
AWS_VOLUME_PROVISIONER_BIN_PATH=/home/ubuntu/volume-manager/target/release/aws-volume-provisioner
AWS_IP_PROVISIONER_BIN_PATH=/home/ubuntu/ip-manager/target/release/aws-ip-provisioner
AVALANCHE_TELEMETRY_CLOUDWATCH_BIN_PATH=/home/ubuntu/avalanche-telemetry/target/release/avalanche-telemetry-cloudwatch

AVALANCHED_AWS_BIN_PATH=/home/ubuntu/avalanche-ops/target/release/avalanched-aws
AVALANCHEGO_BIN_PATH=/home/ubuntu/avalanchego/build/avalanchego

cd /home/ubuntu/avalanche-ops
/home/ubuntu/avalanche-ops/target/release/avalancheup-aws default-spec \
--arch-type amd64 \
--rust-os-type ubuntu20.04 \
--anchor-nodes 4 \
--non-anchor-nodes 4 \
--region ap-northeast-2 \
--instance-mode=on-demand \
--instance-size=4xlarge \
--ip-mode=elastic \
--metrics-fetch-interval-seconds 60 \
--ingress-ipv4-cidr 0.0.0.0/0 \
--upload-artifacts-aws-volume-provisioner-local-bin ${AWS_VOLUME_PROVISIONER_BIN_PATH} \
--upload-artifacts-aws-ip-provisioner-local-bin ${AWS_IP_PROVISIONER_BIN_PATH} \
--upload-artifacts-avalanche-telemetry-cloudwatch-local-bin ${AVALANCHE_TELEMETRY_CLOUDWATCH_BIN_PATH} \
--upload-artifacts-avalanched-aws-local-bin ${AVALANCHED_AWS_BIN_PATH} \
--upload-artifacts-avalanchego-local-bin ${AVALANCHEGO_BIN_PATH} \
--network-name custom \
--keys-to-generate 50 \
--enable-nlb \
--primary-network-validate-period-in-days 32
```

```yaml
version: 2
id: aops-custom-202304-2TKPeY
aad_tag: avalanche-ops-aad-tag
resources:
  identity:
    account_id: '931867039610'
    role_arn: arn:aws:sts::931867039610:assumed-role/jumpcloud-experimental-developer/gyuho.lee@avalabs.org
    user_id: AROA5R542S55AJJWVOGVF:gyuho.lee@avalabs.org
  region: ap-northeast-2
  ingress_ipv4_cidr: 0.0.0.0/0
  s3_bucket: avalanche-ops-202304-42ziec8wgg-ap-northeast-2
  kms_symmetric_default_encrypt_key:
    id: 95c87189-0e73-4462-ba31-3befb680888c
    arn: arn:aws:kms:ap-northeast-2:931867039610:key/95c87189-0e73-4462-ba31-3befb680888c
  ec2_key_name: aops-custom-202304-2TKPeY-ec2-key
  ec2_key_path: /home/ubuntu/aops-custom-202304-2TKPeY-ec2-access.key
  cloudformation_ec2_instance_role: aops-custom-202304-2TKPeY-ec2-instance-role
  cloudformation_ec2_instance_profile_arn: arn:aws:iam::931867039610:instance-profile/aops-custom-202304-2TKPeY-instance-profile
  cloudformation_vpc: aops-custom-202304-2TKPeY-vpc
  cloudformation_vpc_id: vpc-0439425269f4ebc93
  cloudformation_vpc_security_group_id: sg-04b6f70bcf8cfa4df
  cloudformation_vpc_public_subnet_ids:
  - subnet-035f4501874063a4f
  - subnet-0ec6e08f0adbc5301
  cloudformation_asg_anchor_nodes:
  - aops-custom-202304-2TKPeY-anchor-amd64-01
  - aops-custom-202304-2TKPeY-anchor-amd64-02
  - aops-custom-202304-2TKPeY-anchor-amd64-03
  - aops-custom-202304-2TKPeY-anchor-amd64-04
  cloudformation_asg_anchor_nodes_logical_ids:
  - aops-custom-202304-2TKPeY-anchor-amd64-01
  - aops-custom-202304-2TKPeY-anchor-amd64-02
  - aops-custom-202304-2TKPeY-anchor-amd64-03
  - aops-custom-202304-2TKPeY-anchor-amd64-04
  cloudformation_asg_non_anchor_nodes:
  - aops-custom-202304-2TKPeY-non-anchor-amd64-01
  - aops-custom-202304-2TKPeY-non-anchor-amd64-02
  - aops-custom-202304-2TKPeY-non-anchor-amd64-03
  - aops-custom-202304-2TKPeY-non-anchor-amd64-04
  cloudformation_asg_non_anchor_nodes_logical_ids:
  - aops-custom-202304-2TKPeY-non-anchor-amd64-01
  - aops-custom-202304-2TKPeY-non-anchor-amd64-02
  - aops-custom-202304-2TKPeY-non-anchor-amd64-03
  - aops-custom-202304-2TKPeY-non-anchor-amd64-04
  cloudformation_asg_nlb_arn: arn:aws:elasticloadbalancing:ap-northeast-2:931867039610:loadbalancer/net/aops-custom-202304-2TKPeY-nlb/7dc1e1fb90b53789
  cloudformation_asg_nlb_target_group_arn: arn:aws:elasticloadbalancing:ap-northeast-2:931867039610:targetgroup/aops-custom-202304-2TKPeY-tg/5d50684ef30aac69
  cloudformation_asg_nlb_dns_name: aops-custom-202304-2TKPeY-nlb-7dc1e1fb90b53789.elb.ap-northeast-2.amazonaws.com
  cloudformation_asg_launch_template_id: lt-083db80a88191d265
  cloudformation_asg_launch_template_version: '1'
  cloudformation_ssm_install_subnet_chain: aops-custom-202304-2TKPeY-ssm-install-subnet-chain
  cloudwatch_avalanche_metrics_namespace: aops-custom-202304-2TKPeY-avalanche
  created_nodes:
  - kind: anchor
    machineId: i-004218e7af59e6e3c
    nodeId: NodeID-9Cf6ZXc5xUjfS63ZZY6Qe5PtUdDWEE2Eg
    proofOfPossession:
      publicKey: 0xae84eb755fb323debc330252978275886c5558254dd61f76b3036c1eb67d72811fb7849a40e9878f8022c47aed1bf479
      proofOfPossession: 0xb9e4a894161b54f25c8fb48b0fc181019728f92a78b263faaa6d711461cd2689b53c84b69c83a1258c3d4cf0c5224a6208490fa8f5f828a38b61296c7118c05503b35e16e967d7c
be23308afa2d211c1b5ceb8df797fbda492b66738010af26c
    publicIp: 43.200.185.164
    httpEndpoint: http://43.200.185.164:9650
  - kind: anchor
    machineId: i-0004f1cda22ee6d84
    nodeId: NodeID-AGYHGNq3CZjuZ54fsJdrPiPvtChKTejZr
    proofOfPossession:
      publicKey: 0xb12778e3660bfc2f76741784f1c1e76ba58894178c88db1340879964bd175cb0d7ff7e3050bc22060164a89a9223ff97
      proofOfPossession: 0xb654102321216e99686c7a0645093f48fecf7531efbbf402fda9810ada92782b9c6fe564555e3d947fb89f290a46850a0424f8a6f82636eea91bb8ea3b86ddd2fba79c3bf7216f5
eacd972419766e3c663fda293837e6f907888b2ab90435e43
    publicIp: 43.201.208.149
    httpEndpoint: http://43.201.208.149:9650
  - kind: anchor
    machineId: i-0779d859b49002dd8
    nodeId: NodeID-5veLTLisivPaHokQYZpb7usoYw52u6hD8
    proofOfPossession:
      publicKey: 0x96b5c7c898c61f30c24bcc611d1cdf211091b2ba030452e29f02952d218cfa0b7c31306a141407da21e566dfa4faf914
      proofOfPossession: 0x8eb7ce0d1c60256d6888cb1b8d6099f6a7a2f3f67fcaa856f8ab1dd775ebf6a2f79d6539e2d92d9e3449624791482a0a0baebebbb7ee1f7bb3bf65bcc9a4b4d3e1d061cad1dfea0
171d7893885ee546793e2b99f94b1ebe8d4659458ea0a5c36
    publicIp: 52.78.19.151
    httpEndpoint: http://52.78.19.151:9650

machine:
  anchor_nodes: 4
  non_anchor_nodes: 4
  arch_type: amd64
  rust_os_type: ubuntu20.04
  instance_types:
  - m5.4xlarge
  - c5.4xlarge
  instance_mode: on-demand
  ip_mode: elastic
  volume_size_in_gb: 300
avalanched_config:
  log_level: info
  use_default_config: false
enable_nlb: true
disable_logs_auto_removal: false
metrics_fetch_interval_seconds: 60
primary_network_validate_period_in_days: 32
prefunded_keys:
- key_type: hot
  private_key_cb58: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
  private_key_hex: 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027
  addresses:
    1000000:
      x: X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
      p: P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
  short_address: 6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV
  eth_address: 0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC
  h160_address: 0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc
```

---

### After

```bash
AWS_VOLUME_PROVISIONER_BIN_PATH=/home/ubuntu/volume-manager/target/release/aws-volume-provisioner
AWS_IP_PROVISIONER_BIN_PATH=/home/ubuntu/ip-manager/target/release/aws-ip-provisioner
AVALANCHE_TELEMETRY_CLOUDWATCH_BIN_PATH=/home/ubuntu/avalanche-telemetry/target/release/avalanche-telemetry-cloudwatch

AVALANCHED_AWS_BIN_PATH=/home/ubuntu/avalanche-ops/target/release/avalanched-aws
AVALANCHEGO_BIN_PATH=/home/ubuntu/avalanchego/build/avalanchego

cd /home/ubuntu/avalanche-ops
/home/ubuntu/avalanche-ops/target/release/avalancheup-aws default-spec \
--arch-type amd64 \
--rust-os-type ubuntu20.04 \
--anchor-nodes 4 \
--non-anchor-nodes 4 \
--auto-regions 3 \
--instance-mode=on-demand \
--instance-size=4xlarge \
--ip-mode=elastic \
--metrics-fetch-interval-seconds 60 \
--ingress-ipv4-cidr 0.0.0.0/0 \
--upload-artifacts-aws-volume-provisioner-local-bin ${AWS_VOLUME_PROVISIONER_BIN_PATH} \
--upload-artifacts-aws-ip-provisioner-local-bin ${AWS_IP_PROVISIONER_BIN_PATH} \
--upload-artifacts-avalanche-telemetry-cloudwatch-local-bin ${AVALANCHE_TELEMETRY_CLOUDWATCH_BIN_PATH} \
--upload-artifacts-avalanched-aws-local-bin ${AVALANCHED_AWS_BIN_PATH} \
--upload-artifacts-avalanchego-local-bin ${AVALANCHEGO_BIN_PATH} \
--network-name custom \
--keys-to-generate 50 \
--enable-nlb \
--primary-network-validate-period-in-days 32
```

```yaml
version: 3
id: aops-custom-202304-zeB7h6
aad_tag: avalanche-ops-aad-tag
resource:
  regions:
  - us-west-2
  - ap-northeast-2
  - eu-west-1
  s3_bucket: avalanche-ops-202304-42ziec8wgg-us-west-2
  ingress_ipv4_cidr: 0.0.0.0/0
  regional_resources:
    us-west-2:
      region: us-west-2
      ec2_key_name: aops-custom-202304-zeB7h6-ec2-key
      ec2_key_path: /home/ubuntu/aops-custom-202304-zeB7h6-ec2-access.us-west-2.key
    eu-west-1:
      region: eu-west-1
      ec2_key_name: aops-custom-202304-zeB7h6-ec2-key
      ec2_key_path: /home/ubuntu/aops-custom-202304-zeB7h6-ec2-access.eu-west-1.key
    ap-northeast-2:
      region: ap-northeast-2
      ec2_key_name: aops-custom-202304-zeB7h6-ec2-key
      ec2_key_path: /home/ubuntu/aops-custom-202304-zeB7h6-ec2-access.ap-northeast-2.key
machine:
  total_anchor_nodes: 4
  total_non_anchor_nodes: 4
  arch_type: amd64
  rust_os_type: ubuntu20.04
  instance_mode: on-demand
  ip_mode: elastic
  volume_size_in_gb: 300
  regional_machines:
    eu-west-1:
      anchor_nodes: 2
      non_anchor_nodes: 2
      instance_types:
      - c6a.4xlarge
      - m6a.4xlarge
      - m5.4xlarge
      - c5.4xlarge
    us-west-2:
      anchor_nodes: 1
      non_anchor_nodes: 1
      instance_types:
      - c6a.4xlarge
      - m6a.4xlarge
      - m5.4xlarge
      - c5.4xlarge
    ap-northeast-2:
      anchor_nodes: 1
      non_anchor_nodes: 1
      instance_types:
      - m5.4xlarge
      - c5.4xlarge
upload_artifacts:
  avalanched_local_bin: /home/ubuntu/avalanche-ops/target/release/avalanched-aws
  aws_volume_provisioner_local_bin: /home/ubuntu/volume-manager/target/release/aws-volume-provisioner
  aws_ip_provisioner_local_bin: /home/ubuntu/ip-manager/target/release/aws-ip-provisioner
  avalanche_telemetry_cloudwatch_local_bin: /home/ubuntu/avalanche-telemetry/target/release/avalanche-telemetry-cloudwatch
  avalanchego_local_bin: /home/ubuntu/avalanchego/build/avalanchego
  prometheus_metrics_rules_file_path: /home/ubuntu/aops-custom-202304-zeB7h6-prometheus-metrics-rules.yaml
avalanched_config:
  log_level: info
  use_default_config: false
enable_nlb: true
disable_logs_auto_removal: false
metrics_fetch_interval_seconds: 60
primary_network_validate_period_in_days: 32
prefunded_keys:
- key_type: hot
```