### PR TITLE
Add flag s3-upload-timeout

### DIFF
--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -501,8 +501,11 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         ResetColor
     )?;
 
-    let shared_config =
-        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(opts.s3_upload_timeout))).await;
+    let shared_config = aws_manager::load_config(
+        Some(opts.s3_region.clone()),
+        Some(Duration::from_secs(opts.s3_upload_timeout)),
+    )
+    .await;
     let sts_manager = sts::Manager::new(&shared_config);
     let s3_manager = s3::Manager::new(&shared_config);
 

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -356,7 +356,11 @@ async fn main() -> io::Result<()> {
                     .get_one::<String>("S3_KEY_PREFIX")
                     .unwrap_or(&String::new())
                     .clone(),
-
+                s3_upload_timeout: sub_matches
+                    .get_one::<u64>("S3_UPLOAD_TIMEOUT")
+                    .unwrap_or(&30)
+                    .clone(),
+                    
                 chain_rpc_url: sub_matches
                     .get_one::<String>("CHAIN_RPC_URL")
                     .unwrap()

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -360,7 +360,7 @@ async fn main() -> io::Result<()> {
                     .get_one::<u64>("S3_UPLOAD_TIMEOUT")
                     .unwrap_or(&30)
                     .clone(),
-                    
+
                 chain_rpc_url: sub_matches
                     .get_one::<String>("CHAIN_RPC_URL")
                     .unwrap()


### PR DESCRIPTION
Adds the flag `s3-upload-timeout` to the `install-subnet-chain` command for uploading the VM binary to s3.