### PR TITLE
feat: Add chain-alias option to install_subnet_chain

### DIFF
--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -2463,6 +2463,7 @@ cat /tmp/{node_id}.crt
 --vm-binary-local-path REPLACE_ME \\
 --vm-binary-remote-dir {vm_plugin_remote_dir} \\
 --chain-name subnetevm \\
+--chain-alias mysubnet \\
 --chain-genesis-path /tmp/subnet-evm-genesis.json \\
 --chain-config-local-path /tmp/subnet-evm-chain-config.json \\
 --chain-config-remote-dir {chain_config_remote_dir} \\

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -1027,16 +1027,12 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
     if !opts.chain_alias.is_empty() {
         match json_client_admin::alias_chain(
             &opts.chain_rpc_url,
-            opts.chain_name.clone(),
+            subnet_id.to_string(),
             opts.chain_alias.clone(),
         )
         .await
         {
-            Ok(_) => log::info!(
-                "set alias {} for chain {}",
-                &opts.chain_alias,
-                &opts.chain_name
-            ),
+            Ok(_) => log::info!("set alias {} for chain {}", &opts.chain_alias, subnet_id,),
             Err(e) => {
                 execute!(
                     stdout(),
@@ -1048,7 +1044,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
                     ErrorKind::Other,
                     format!(
                         "error setting alias {} for chain {}: {}",
-                        opts.chain_alias, opts.chain_name, e
+                        opts.chain_alias, subnet_id, e
                     ),
                 ));
             }

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -389,6 +389,10 @@ async fn main() -> io::Result<()> {
                     .unwrap_or(&String::new())
                     .clone(),
                 chain_name: sub_matches.get_one::<String>("CHAIN_NAME").unwrap().clone(),
+                chain_alias: sub_matches
+                    .get_one::<String>("CHAIN_ALIAS")
+                    .unwrap_or(&String::new())
+                    .clone(),
                 chain_genesis_path: sub_matches
                     .get_one::<String>("CHAIN_GENESIS_PATH")
                     .unwrap()


### PR DESCRIPTION
Adds the ability to create an alias for a subnet.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
