### PR TITLE
fix: Remove conflicting short name from spec and skip-prompt

### DIFF
--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -126,7 +126,6 @@ pub fn command() -> Command {
         .arg(
             Arg::new("SKIP_PROMPT")
                 .long("skip-prompt")
-                .short('s')
                 .help("Skips prompt mode")
                 .required(false)
                 .num_args(0),


### PR DESCRIPTION
Each short name for a flag must be unique per clap

<img width="971" alt="image" src="https://github.com/ava-labs/avalanche-ops/assets/31546601/3752a984-1db1-4dba-acbc-18808418f272">

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
