### PR TITLE
apply: Add ability to run scripts from the dev machine

### DIFF
--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -67,7 +67,10 @@ pub struct Spec {
     pub create_dev_machine: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_machine: Option<DevMachine>,
-
+    /// Filepath to a local directory containing bash scripts.
+    /// These scripts will be invoked on the dev machine upon startup.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dev_machine_scripts_path: Option<std::path::PathBuf>,
     /// Set "true" to enable NLB.
     #[serde(default)]
     pub enable_nlb: bool,
@@ -386,6 +389,7 @@ pub struct DefaultSpecOption {
     pub keep_resources_except_asg_ssm: bool,
     pub create_dev_machine: bool,
     pub dev_machine_ssh_key_email: String,
+    pub dev_machine_scripts_path: Option<Box<std::path::PathBuf>>,
 
     pub enable_nlb: bool,
     pub disable_logs_auto_removal: bool,
@@ -933,6 +937,7 @@ impl Spec {
                 keep_resources_except_asg_ssm: opts.keep_resources_except_asg_ssm,
                 create_dev_machine: opts.create_dev_machine,
                 dev_machine,
+                dev_machine_scripts_path: None,
 
                 enable_nlb: opts.enable_nlb,
                 disable_logs_auto_removal: opts.disable_logs_auto_removal,
@@ -1439,6 +1444,7 @@ coreth_chain_config:
         keep_resources_except_asg_ssm: false,
         create_dev_machine: false,
         dev_machine: None,
+        dev_machine_scripts_path: None,
 
         enable_nlb: false,
         disable_logs_auto_removal: false,

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -67,10 +67,9 @@ pub struct Spec {
     pub create_dev_machine: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_machine: Option<DevMachine>,
-    /// Filepath to a local directory containing bash scripts.
-    /// These scripts will be invoked on the dev machine upon startup.
+    /// Local filepath to a bash script to be executed on the dev machine.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dev_machine_scripts_dir_path: Option<std::path::PathBuf>,
+    pub dev_machine_script: Option<std::path::PathBuf>,
     /// Set "true" to enable NLB.
     #[serde(default)]
     pub enable_nlb: bool,
@@ -389,7 +388,7 @@ pub struct DefaultSpecOption {
     pub keep_resources_except_asg_ssm: bool,
     pub create_dev_machine: bool,
     pub dev_machine_ssh_key_email: String,
-    pub dev_machine_scripts_dir_path: Option<std::path::PathBuf>,
+    pub dev_machine_script: Option<std::path::PathBuf>,
 
     pub enable_nlb: bool,
     pub disable_logs_auto_removal: bool,
@@ -937,7 +936,7 @@ impl Spec {
                 keep_resources_except_asg_ssm: opts.keep_resources_except_asg_ssm,
                 create_dev_machine: opts.create_dev_machine,
                 dev_machine,
-                dev_machine_scripts_dir_path: None,
+                dev_machine_script: None,
 
                 enable_nlb: opts.enable_nlb,
                 disable_logs_auto_removal: opts.disable_logs_auto_removal,
@@ -1444,7 +1443,7 @@ coreth_chain_config:
         keep_resources_except_asg_ssm: false,
         create_dev_machine: false,
         dev_machine: None,
-        dev_machine_scripts_dir_path: None,
+        dev_machine_script: None,
 
         enable_nlb: false,
         disable_logs_auto_removal: false,

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -70,7 +70,7 @@ pub struct Spec {
     /// Filepath to a local directory containing bash scripts.
     /// These scripts will be invoked on the dev machine upon startup.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dev_machine_scripts_path: Option<std::path::PathBuf>,
+    pub dev_machine_scripts_dir_path: Option<std::path::PathBuf>,
     /// Set "true" to enable NLB.
     #[serde(default)]
     pub enable_nlb: bool,
@@ -389,7 +389,7 @@ pub struct DefaultSpecOption {
     pub keep_resources_except_asg_ssm: bool,
     pub create_dev_machine: bool,
     pub dev_machine_ssh_key_email: String,
-    pub dev_machine_scripts_path: Option<std::path::PathBuf>,
+    pub dev_machine_scripts_dir_path: Option<std::path::PathBuf>,
 
     pub enable_nlb: bool,
     pub disable_logs_auto_removal: bool,
@@ -937,7 +937,7 @@ impl Spec {
                 keep_resources_except_asg_ssm: opts.keep_resources_except_asg_ssm,
                 create_dev_machine: opts.create_dev_machine,
                 dev_machine,
-                dev_machine_scripts_path: None,
+                dev_machine_scripts_dir_path: None,
 
                 enable_nlb: opts.enable_nlb,
                 disable_logs_auto_removal: opts.disable_logs_auto_removal,
@@ -1444,7 +1444,7 @@ coreth_chain_config:
         keep_resources_except_asg_ssm: false,
         create_dev_machine: false,
         dev_machine: None,
-        dev_machine_scripts_path: None,
+        dev_machine_scripts_dir_path: None,
 
         enable_nlb: false,
         disable_logs_auto_removal: false,

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -389,7 +389,7 @@ pub struct DefaultSpecOption {
     pub keep_resources_except_asg_ssm: bool,
     pub create_dev_machine: bool,
     pub dev_machine_ssh_key_email: String,
-    pub dev_machine_scripts_path: Option<Box<std::path::PathBuf>>,
+    pub dev_machine_scripts_path: Option<std::path::PathBuf>,
 
     pub enable_nlb: bool,
     pub disable_logs_auto_removal: bool,

--- a/avalancheup-aws/src/apply/dev_machine.rs
+++ b/avalancheup-aws/src/apply/dev_machine.rs
@@ -1,0 +1,51 @@
+use std::io::{stdout, Error, ErrorKind, Write};
+/// Module for extracting and running dev machine scripts on startup
+/// Users can provide a path to a script file, or a directory containing multiple scripts, to execute.
+/// Note: scripts must be written in bash with a bash shebang included.
+/// Note: scripts must ensure that the network is up and running before executing(polling the liveness API for example).
+use std::path::Path;
+use std::process::Command;
+
+/// Parses the user-provided path to an script or a directory containing scripts for the dev machine to execute.
+#[allow(dead_code)]
+pub fn parse_path(provided_path: Option<Box<Path>>) -> Result<Option<Vec<Box<Path>>>, Error> {
+    if provided_path.is_none() {
+        return Ok(None);
+    }
+
+    let mut out_vec: Vec<Box<Path>> = Vec::new();
+
+    if let Some(path) = provided_path {
+        if !path.exists() {
+            return Err(Error::new(ErrorKind::NotFound, "{path} not found"));
+        }
+        if path.is_file() {
+            // return the path to the file
+            out_vec.push(path);
+        } else if path.is_dir() {
+            // return the paths to a series of files in the directory
+            todo!();
+        }
+    }
+    Ok(Some(out_vec))
+}
+
+#[allow(dead_code)]
+pub fn execute_script(scripts: Vec<Box<Path>>) -> Result<(), Error> {
+    for script in scripts {
+        let output = Command::new("/bin/sh")
+            .arg("-C")
+            .arg(script.as_os_str())
+            .output()
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("{:?} script failed to execute: {e}", script.as_os_str()),
+                )
+            })?;
+
+        stdout().write_all(&output.stdout).unwrap();
+    }
+
+    Ok(())
+}

--- a/avalancheup-aws/src/apply/dev_machine.rs
+++ b/avalancheup-aws/src/apply/dev_machine.rs
@@ -1,64 +1,38 @@
-use std::fs;
-use std::io::{self, stdout, Error, ErrorKind, Write};
-/// Module for extracting and running dev machine scripts on startup
-/// Users provide a path to a directory containing multiple scripts, to execute.
-/// Scripts are executed in lexicographical order.
-/// Scripts should be placed at the top level without any subdirectories.
+//! Module for extracting and running dev machine scripts on startup.
+use std::io::{stdout, Error, ErrorKind, Write};
 use std::path::PathBuf;
 use std::process::Command;
 
-/// Parses the user-provided path to a directory containing scripts for the dev machine to execute.
+/// Parses the user-provided path to a script for the dev machine to execute.
 #[allow(dead_code)]
-pub fn parse_path(provided_path: PathBuf) -> Result<Vec<PathBuf>, Error> {
-    let mut out_vec: Vec<PathBuf> = Vec::new();
-
+pub fn parse_path(provided_path: PathBuf) -> Result<PathBuf, Error> {
     if !provided_path.exists() {
         return Err(Error::new(ErrorKind::NotFound, "{provided_path} not found"));
     }
-    if provided_path.is_file() {
+    if !provided_path.is_file() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
-            "{provided_path} is a file, not a directory",
+            "{provided_path} is not a file",
         ));
     }
 
-    // sort the entries in the directory lexicographically
-    let mut entries = fs::read_dir(provided_path)?
-        .map(|res| res.map(|e| e.path()))
-        .collect::<Result<Vec<_>, io::Error>>()?;
-    entries.sort();
-
-    // return the paths to a series of files in the directory
-    for entry in entries {
-        if entry.is_file() {
-            out_vec.push(entry);
-        } else {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "{provided_path} should only contain files, not directories",
-            ));
-        }
-    }
-
-    Ok(out_vec)
+    Ok(provided_path)
 }
 
 #[allow(dead_code)]
-pub fn execute_script(scripts: Vec<PathBuf>) -> Result<(), Error> {
-    for script in scripts {
-        let output = Command::new("/bin/sh")
-            .arg("-C")
-            .arg(script.as_os_str())
-            .output()
-            .map_err(|e| {
-                Error::new(
-                    ErrorKind::InvalidInput,
-                    format!("{:?} script failed to execute: {e}", script.as_os_str()),
-                )
-            })?;
+pub fn execute_script(script: PathBuf) -> Result<(), Error> {
+    let output = Command::new("/bin/sh")
+        .arg("-C")
+        .arg(script.as_os_str())
+        .output()
+        .map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!("{:?} script failed to execute: {e}", script.as_os_str()),
+            )
+        })?;
 
-        stdout().write_all(&output.stdout).unwrap();
-    }
+    stdout().write_all(&output.stdout).unwrap();
 
     Ok(())
 }
@@ -69,33 +43,13 @@ mod test {
     fn test_parse_path() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("my-script.sh");
-        let _ = std::fs::File::create(file_path).unwrap();
+        let _ = std::fs::File::create(file_path.clone()).unwrap();
 
-        let scripts_dir = std::path::PathBuf::from(dir.path());
-        let result = super::parse_path(scripts_dir.clone());
+        let result = super::parse_path(file_path);
         assert!(result.is_ok());
 
         // create subdirectory and try again (error)
-        let sub_dir = dir.path().join("subdir");
-        std::fs::DirBuilder::new().create(sub_dir).unwrap();
-        let result = super::parse_path(scripts_dir);
+        let result = super::parse_path(dir.path().to_path_buf());
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_sorting() {
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("00_my-script.sh");
-        let _ = std::fs::File::create(file_path).unwrap();
-        let file_path = dir.path().join("01_my-script.sh");
-        let _ = std::fs::File::create(file_path).unwrap();
-        let file_path = dir.path().join("02_my-script.sh");
-        let _ = std::fs::File::create(file_path).unwrap();
-
-        let scripts_dir = std::path::PathBuf::from(dir.path());
-        let result = super::parse_path(scripts_dir).unwrap();
-        assert_eq!(result[0], dir.path().join("00_my-script.sh"));
-        assert_eq!(result[1], dir.path().join("01_my-script.sh"));
-        assert_eq!(result[2], dir.path().join("02_my-script.sh"));
     }
 }

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -2646,6 +2646,19 @@ default-spec --log-level=info --funded-keys={funded_keys} --region={region} --up
             .await
             .expect("failed put_object ConfigFile");
 
+        // Put dev machine scripts into s3 if specified
+        if let Some(dev_scripts_dir) = spec.dev_machine_scripts_dir_path.clone() {
+            default_s3_manager
+                .put_object(
+                    dev_scripts_dir.to_str().unwrap(),
+                    &spec.resource.s3_bucket,
+                    &avalanche_ops::aws::spec::StorageNamespace::ConfigFile(spec.id.clone())
+                        .encode(),
+                )
+                .await
+                .expect("failed put_object dev machine scripts");
+        }
+
         let mut regional_common_dev_machine_asg_params = region_to_common_dev_machine_asg_params
             .get(&spec.resource.regions[0])
             .unwrap()
@@ -2905,6 +2918,8 @@ default-spec --log-level=info --funded-keys={funded_keys} --region={region} --up
                 Err(e) => log::warn!("failed to run ssh command {}", e),
             }
         }
+
+        // Run dev-machine scripts
 
         //
         //

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -2647,16 +2647,16 @@ default-spec --log-level=info --funded-keys={funded_keys} --region={region} --up
             .expect("failed put_object ConfigFile");
 
         // Put dev machine scripts into s3 if specified
-        if let Some(dev_scripts_dir) = spec.dev_machine_scripts_dir_path.clone() {
+        if let Some(script) = spec.dev_machine_script.clone() {
             default_s3_manager
                 .put_object(
-                    dev_scripts_dir.to_str().unwrap(),
+                    script.to_str().unwrap(),
                     &spec.resource.s3_bucket,
                     &avalanche_ops::aws::spec::StorageNamespace::ConfigFile(spec.id.clone())
                         .encode(),
                 )
                 .await
-                .expect("failed put_object dev machine scripts");
+                .expect("failed put_object dev machine script");
         }
 
         let mut regional_common_dev_machine_asg_params = region_to_common_dev_machine_asg_params
@@ -2918,8 +2918,6 @@ default-spec --log-level=info --funded-keys={funded_keys} --region={region} --up
                 Err(e) => log::warn!("failed to run ssh command {}", e),
             }
         }
-
-        // Run dev-machine scripts
 
         //
         //

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -12,6 +12,8 @@ use std::{
     },
 };
 
+mod dev_machine;
+
 use avalanche_types::{
     ids, jsonrpc::client::health as jsonrpc_client_health,
     jsonrpc::client::info as jsonrpc_client_info, key, units, wallet,

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -110,8 +110,8 @@ async fn main() -> io::Result<()> {
                     .get_one::<String>("DEV_MACHINE_SSH_KEY_EMAIL")
                     .unwrap_or(&String::new())
                     .clone(),
-                dev_machine_scripts_dir_path: sub_matches
-                    .get_one::<Option<std::path::PathBuf>>("dev_machine_scripts_dir_path")
+                dev_machine_script: sub_matches
+                    .get_one::<Option<std::path::PathBuf>>("dev_machine_script")
                     .unwrap_or(&None)
                     .clone(),
 

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> io::Result<()> {
                     .unwrap_or(&String::new())
                     .clone(),
                 dev_machine_scripts_path: sub_matches
-                    .get_one::<Option<Box<std::path::Path>>>("DEV_MACHINE_SCRIPTS_PATH")
+                    .get_one::<Option<std::path::PathBuf>>("DEV_MACHINE_SCRIPTS_PATH")
                     .unwrap_or(&None)
                     .clone(),
 

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -110,6 +110,10 @@ async fn main() -> io::Result<()> {
                     .get_one::<String>("DEV_MACHINE_SSH_KEY_EMAIL")
                     .unwrap_or(&String::new())
                     .clone(),
+                dev_machine_scripts_path: sub_matches
+                    .get_one::<Option<Box<std::path::Path>>>("DEV_MACHINE_SCRIPTS_PATH")
+                    .unwrap_or(&None)
+                    .clone(),
 
                 ingress_ipv4_cidr: sub_matches
                     .get_one::<String>("INGRESS_IPV4_CIDR")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -110,8 +110,8 @@ async fn main() -> io::Result<()> {
                     .get_one::<String>("DEV_MACHINE_SSH_KEY_EMAIL")
                     .unwrap_or(&String::new())
                     .clone(),
-                dev_machine_scripts_path: sub_matches
-                    .get_one::<Option<std::path::PathBuf>>("DEV_MACHINE_SCRIPTS_PATH")
+                dev_machine_scripts_dir_path: sub_matches
+                    .get_one::<Option<std::path::PathBuf>>("dev_machine_scripts_dir_path")
                     .unwrap_or(&None)
                     .clone(),
 


### PR DESCRIPTION
Preliminary work to allow the dev-machine to run scripts on startup. 

1 / 2

Add the `dev_machine_script` flag and upload the script to s3 on `apply`. 

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
