### PR TITLE
*: Update aws-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,29 +76,23 @@ https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalanched-aw
 
 To use `avalancheup` you need AWS credentials stored locally to authenticate with against the AWS API.
 
-Run `aws sts get-caller-identity` to check whether you are logged in successfully on your machine.
+Use the [aws CLI tool](https://aws.amazon.com/cli/) to login to AWS from the command line. It is recommended to start from a clean `.aws` folder each time you use avalanche-ops. 
 
-To generate temporary credentials via SSO, use `aws configure` or the `saml2aws` tool. For example,
-
+Use `aws configure sso` to login, with the following settings:
 ```
-$ saml2aws configure \
---idp-account='default' \
---idp-provider='provider' \
---mfa='Auto' \
---url='https://sso.provider.com/saml2/aws' \
---username='YOUR EMAIL@ORG.org' \
---role='arn:aws:iam::XXXXXXXXXXX:role/developer' \
---profile='default' \
---skip-prompt
-
-$ saml2aws login \
---idp-account=default \
---force \
---session-duration=43200
-
-# verify account login was successful
-$ aws sts get-caller-identity
+SSO session name: <EMPTY> (hit enter)
+SSO start URL: <SSO ENDPOINT>
+SSO region: <REGION>
 ```
+
+After that the tool will login to AWS via the browser. Then enter the following settings:
+```
+CLI default client Region: <REGION>
+CLI default output format: json
+CLI profile name: <YOUR USERNAME>
+```
+
+Once logged in, you can use the avalanche-ops suite of tools successfully. Note that the daemons and other backend services that run directly in AWS have their own authentication patterns. 
 
 ## TODOs
 

--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -2,11 +2,11 @@
 name = "avalanche-kms"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [dependencies]
 avalanche-types = { version = "0.0.395", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.13", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.26.1"
 dialoguer = "0.10.4"

--- a/avalanche-kms/src/create/mod.rs
+++ b/avalanche-kms/src/create/mod.rs
@@ -194,8 +194,17 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(0),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile-name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     log_level: &str,
     region: &str,
@@ -209,6 +218,7 @@ pub async fn execute(
     evm_funding_hotkey: &str,
     evm_funding_amount_navax: U256,
     skip_prompt: bool,
+    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -239,9 +249,12 @@ pub async fn execute(
             "requesting to create new {keys} KMS key(s) with prefix '{key_name_prefix}' (in the {region}, grantee principal {grantee_principal}, keys file output {keys_file_output})"
         );
 
-            let shared_config =
-                aws_manager::load_config(Some(region.to_string()), Some(Duration::from_secs(30)))
-                    .await;
+            let shared_config = aws_manager::load_config(
+                Some(region.to_string()),
+                Some(profile_name),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
             let kms_manager = kms::Manager::new(&shared_config);
 
             let sts_manager = sts::Manager::new(&shared_config);

--- a/avalanche-kms/src/delete/mod.rs
+++ b/avalanche-kms/src/delete/mod.rs
@@ -58,6 +58,14 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(0),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 pub async fn execute(
@@ -66,6 +74,7 @@ pub async fn execute(
     key_arn: &str,
     pending_windows_in_days: i32,
     unsafe_skip_prompt: bool,
+    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -74,8 +83,12 @@ pub async fn execute(
 
     log::info!("requesting to delete {key_arn} ({region}) in {pending_windows_in_days} days");
 
-    let shared_config =
-        aws_manager::load_config(Some(region.to_string()), Some(Duration::from_secs(30))).await;
+    let shared_config = aws_manager::load_config(
+        Some(region.to_string()),
+        Some(profile_name),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let kms_manager = kms::Manager::new(&shared_config);
 
     let sts_manager = sts::Manager::new(&shared_config);

--- a/avalanche-kms/src/delete/mod.rs
+++ b/avalanche-kms/src/delete/mod.rs
@@ -60,7 +60,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalanche-kms/src/info/mod.rs
+++ b/avalanche-kms/src/info/mod.rs
@@ -62,6 +62,14 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 pub async fn execute(
@@ -70,6 +78,7 @@ pub async fn execute(
     key_type: &str,
     key: &str,
     chain_rpc_url: &str,
+    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -101,8 +110,12 @@ pub async fn execute(
     };
     log::info!("network Id: {network_id}");
 
-    let shared_config =
-        aws_manager::load_config(Some(region.to_string()), Some(Duration::from_secs(30))).await;
+    let shared_config = aws_manager::load_config(
+        Some(region.to_string()),
+        Some(profile_name),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
 
     let sts_manager = sts::Manager::new(&shared_config);
     let current_identity = sts_manager.get_identity().await.unwrap();

--- a/avalanche-kms/src/info/mod.rs
+++ b/avalanche-kms/src/info/mod.rs
@@ -64,7 +64,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalanche-kms/src/main.rs
+++ b/avalanche-kms/src/main.rs
@@ -131,6 +131,10 @@ async fn main() -> io::Result<()> {
                 &evm_funding_hotkey,
                 evm_funding_amount_navax,
                 sub_matches.get_flag("SKIP_PROMPT"),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap()
+                    .clone(),
             )
             .await
             .unwrap();
@@ -150,6 +154,10 @@ async fn main() -> io::Result<()> {
                 &sub_matches.get_one::<String>("KEY_ARN").unwrap().clone(),
                 pending_windows_in_days,
                 sub_matches.get_flag("UNSAFE_SKIP_PROMPT"),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap()
+                    .clone(),
             )
             .await
             .unwrap();
@@ -167,6 +175,10 @@ async fn main() -> io::Result<()> {
                 &sub_matches
                     .get_one::<String>("CHAIN_RPC_URL")
                     .unwrap_or(&String::new())
+                    .clone(),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap()
                     .clone(),
             )
             .await

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -2,7 +2,7 @@
 name = "avalanche-ops"
 version = "0.8.5" # https://crates.io/crates/avalanche-ops
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 publish = true
 description = "avalanche-ops spec"
 repository = "https://github.com/ava-labs/avalanche-ops"
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 avalanche-types = { version = "0.0.395", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.13", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.10"
 dir-manager = "0.0.1"
 env_logger = "0.10.0"

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -38,6 +38,10 @@ pub struct Spec {
     #[serde(default)]
     pub aad_tag: String,
 
+    /// AWS profile to use for API calls.
+    #[serde(default)]
+    pub profile_name: String,
+
     /// AWS resources if run in AWS.
     pub resource: Resource,
     /// Defines how the underlying infrastructure is set up.
@@ -419,6 +423,8 @@ pub struct DefaultSpecOption {
     pub coreth_state_sync_enabled: bool,
 
     pub spec_file_path: String,
+    /// The AWS profile to use.
+    pub profile_name: String,
 }
 
 impl Spec {
@@ -907,6 +913,8 @@ impl Spec {
             volume_size_in_gb,
         };
 
+        let profile_name = opts.profile_name;
+
         Ok((
             Self {
                 version: VERSION,
@@ -937,6 +945,7 @@ impl Spec {
                 avalanchego_config,
                 coreth_chain_config,
                 avalanchego_genesis_template,
+                profile_name,
             },
             spec_file_path,
         ))
@@ -1387,6 +1396,7 @@ coreth_chain_config:
 
         id: id.clone(),
         aad_tag: String::from("test"),
+        profile_name: String::from("default"),
 
         resource: Resource {
             regions: vec![String::from("us-west-2")],

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -2,7 +2,7 @@
 name = "avalanched-aws"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [[bin]]
 name = "avalanched-aws"
@@ -14,7 +14,7 @@ avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.107" # https://crates.io/crates/avalanche-telemetry-cloudwatch-installer
 avalanche-types = { version = "0.0.395", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.96" # https://crates.io/crates/aws-ip-provisioner-installer
-aws-manager = { version = "0.28.13", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalanched-aws/src/agent/mod.rs
+++ b/avalanched-aws/src/agent/mod.rs
@@ -74,7 +74,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalanched-aws/src/install_artifacts/mod.rs
+++ b/avalanched-aws/src/install_artifacts/mod.rs
@@ -106,14 +106,6 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(1),
         )
-        .arg(
-            Arg::new("PROFILE_NAME")
-                .long("profile-name")
-                .help("Sets the AWS credential profile name for API calls/endpoints")
-                .required(false)
-                .default_value("default")
-                .num_args(1),
-        )
 }
 
 /// 1. If the S3 key is not empty, download from S3.
@@ -133,7 +125,6 @@ pub async fn execute(
     aws_ip_provisioner_local_path: &str,
     avalanche_telemetry_cloudwatch_s3_key: &str,
     avalanche_telemetry_cloudwatch_local_path: &str,
-    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -142,7 +133,7 @@ pub async fn execute(
 
     let shared_config = aws_manager::load_config(
         Some(s3_region.to_string()),
-        Some(profile_name),
+        None,
         Some(Duration::from_secs(30)),
     )
     .await;

--- a/avalanched-aws/src/install_artifacts/mod.rs
+++ b/avalanched-aws/src/install_artifacts/mod.rs
@@ -108,7 +108,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalanched-aws/src/install_artifacts/mod.rs
+++ b/avalanched-aws/src/install_artifacts/mod.rs
@@ -106,6 +106,14 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 /// 1. If the S3 key is not empty, download from S3.
@@ -125,14 +133,19 @@ pub async fn execute(
     aws_ip_provisioner_local_path: &str,
     avalanche_telemetry_cloudwatch_s3_key: &str,
     avalanche_telemetry_cloudwatch_local_path: &str,
+    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, log_level),
     );
 
-    let shared_config =
-        aws_manager::load_config(Some(s3_region.to_string()), Some(Duration::from_secs(30))).await;
+    let shared_config = aws_manager::load_config(
+        Some(s3_region.to_string()),
+        Some(profile_name),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let s3_manager = s3::Manager::new(&shared_config);
 
     let need_github_download = if !avalanchego_s3_key.is_empty() {

--- a/avalanched-aws/src/install_chain/mod.rs
+++ b/avalanched-aws/src/install_chain/mod.rs
@@ -67,7 +67,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalanched-aws/src/install_chain/mod.rs
+++ b/avalanched-aws/src/install_chain/mod.rs
@@ -21,6 +21,7 @@ pub struct Flags {
 
     pub chain_config_s3_key: String,
     pub chain_config_local_path: String,
+    pub profile_name: String,
 }
 
 pub fn command() -> Command {
@@ -64,6 +65,14 @@ pub fn command() -> Command {
                 .required(true)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 pub async fn execute(opts: Flags) -> io::Result<()> {
@@ -72,8 +81,12 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, opts.log_level),
     );
 
-    let shared_config =
-        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
+    let shared_config = aws_manager::load_config(
+        Some(opts.s3_region.clone()),
+        Some(opts.profile_name),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let s3_manager = s3::Manager::new(&shared_config);
 
     let path = Path::new(&opts.chain_config_local_path);

--- a/avalanched-aws/src/install_chain/mod.rs
+++ b/avalanched-aws/src/install_chain/mod.rs
@@ -21,7 +21,6 @@ pub struct Flags {
 
     pub chain_config_s3_key: String,
     pub chain_config_local_path: String,
-    pub profile_name: String,
 }
 
 pub fn command() -> Command {
@@ -65,14 +64,6 @@ pub fn command() -> Command {
                 .required(true)
                 .num_args(1),
         )
-        .arg(
-            Arg::new("PROFILE_NAME")
-                .long("profile-name")
-                .help("Sets the AWS credential profile name for API calls/endpoints")
-                .required(false)
-                .default_value("default")
-                .num_args(1),
-        )
 }
 
 pub async fn execute(opts: Flags) -> io::Result<()> {
@@ -83,7 +74,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
 
     let shared_config = aws_manager::load_config(
         Some(opts.s3_region.clone()),
-        Some(opts.profile_name),
+        None,
         Some(Duration::from_secs(30)),
     )
     .await;

--- a/avalanched-aws/src/install_subnet/mod.rs
+++ b/avalanched-aws/src/install_subnet/mod.rs
@@ -29,6 +29,7 @@ pub struct Flags {
 
     pub subnet_id_to_track: String,
     pub avalanchego_config_path: String,
+    pub profile_name: String,
 }
 
 pub fn command() -> Command {
@@ -102,6 +103,14 @@ pub fn command() -> Command {
                 .required(true)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 pub async fn execute(opts: Flags) -> io::Result<()> {
@@ -110,8 +119,12 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, opts.log_level),
     );
 
-    let shared_config =
-        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
+    let shared_config = aws_manager::load_config(
+        Some(opts.s3_region.clone()),
+        Some(opts.profile_name),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let s3_manager = s3::Manager::new(&shared_config);
 
     if !opts.subnet_config_s3_key.is_empty() && !opts.subnet_config_s3_key.is_empty() {

--- a/avalanched-aws/src/install_subnet/mod.rs
+++ b/avalanched-aws/src/install_subnet/mod.rs
@@ -29,7 +29,6 @@ pub struct Flags {
 
     pub subnet_id_to_track: String,
     pub avalanchego_config_path: String,
-    pub profile_name: String,
 }
 
 pub fn command() -> Command {
@@ -103,14 +102,6 @@ pub fn command() -> Command {
                 .required(true)
                 .num_args(1),
         )
-        .arg(
-            Arg::new("PROFILE_NAME")
-                .long("profile-name")
-                .help("Sets the AWS credential profile name for API calls/endpoints")
-                .required(false)
-                .default_value("default")
-                .num_args(1),
-        )
 }
 
 pub async fn execute(opts: Flags) -> io::Result<()> {
@@ -121,7 +112,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
 
     let shared_config = aws_manager::load_config(
         Some(opts.s3_region.clone()),
-        Some(opts.profile_name),
+        None,
         Some(Duration::from_secs(30)),
     )
     .await;

--- a/avalanched-aws/src/install_subnet/mod.rs
+++ b/avalanched-aws/src/install_subnet/mod.rs
@@ -105,7 +105,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalanched-aws/src/main.rs
+++ b/avalanched-aws/src/main.rs
@@ -31,6 +31,10 @@ async fn main() {
                     .clone(),
                 use_default_config: sub_matches.get_flag("USE_DEFAULT_CONFIG"),
                 publish_periodic_node_info: sub_matches.get_flag("PUBLISH_PERIODIC_NODE_INFO"),
+                profile_name: sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             };
             agent::execute(opts).await.unwrap();
         }
@@ -79,6 +83,10 @@ async fn main() {
                 sub_matches
                     .get_one::<String>("AVALANCHE_TELEMETRY_CLOUDWATCH_LOCAL_PATH")
                     .unwrap_or(&String::new()),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             )
             .await
             .unwrap();
@@ -122,6 +130,10 @@ async fn main() {
                     .get_one::<String>("AVALANCHEGO_CONFIG_PATH")
                     .unwrap()
                     .to_string(),
+                profile_name: sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             })
             .await
             .unwrap();
@@ -149,6 +161,10 @@ async fn main() {
                     .get_one::<String>("CHAIN_CONFIG_LOCAL_PATH")
                     .unwrap()
                     .to_string(),
+                profile_name: sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             })
             .await
             .unwrap();

--- a/avalanched-aws/src/main.rs
+++ b/avalanched-aws/src/main.rs
@@ -31,10 +31,6 @@ async fn main() {
                     .clone(),
                 use_default_config: sub_matches.get_flag("USE_DEFAULT_CONFIG"),
                 publish_periodic_node_info: sub_matches.get_flag("PUBLISH_PERIODIC_NODE_INFO"),
-                profile_name: sub_matches
-                    .get_one::<String>("PROFILE_NAME")
-                    .unwrap_or(&String::from("default"))
-                    .clone(),
             };
             agent::execute(opts).await.unwrap();
         }
@@ -83,10 +79,6 @@ async fn main() {
                 sub_matches
                     .get_one::<String>("AVALANCHE_TELEMETRY_CLOUDWATCH_LOCAL_PATH")
                     .unwrap_or(&String::new()),
-                sub_matches
-                    .get_one::<String>("PROFILE_NAME")
-                    .unwrap_or(&String::from("default"))
-                    .clone(),
             )
             .await
             .unwrap();
@@ -130,10 +122,6 @@ async fn main() {
                     .get_one::<String>("AVALANCHEGO_CONFIG_PATH")
                     .unwrap()
                     .to_string(),
-                profile_name: sub_matches
-                    .get_one::<String>("PROFILE_NAME")
-                    .unwrap_or(&String::from("default"))
-                    .clone(),
             })
             .await
             .unwrap();
@@ -161,10 +149,6 @@ async fn main() {
                     .get_one::<String>("CHAIN_CONFIG_LOCAL_PATH")
                     .unwrap()
                     .to_string(),
-                profile_name: sub_matches
-                    .get_one::<String>("PROFILE_NAME")
-                    .unwrap_or(&String::from("default"))
-                    .clone(),
             })
             .await
             .unwrap();

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -2,7 +2,7 @@
 name = "avalancheup-aws"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [[bin]]
 name = "avalancheup-aws"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-types = { version = "0.0.395", features = ["avalanchego", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-dev-machine = "0.0.17"
-aws-manager = { version = "0.28.13", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -67,7 +67,12 @@ pub fn command() -> Command {
 // 50-minute
 const MAX_WAIT_SECONDS: u64 = 50 * 60;
 
-pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -> io::Result<()> {
+pub async fn execute(
+    log_level: &str,
+    spec_file_path: &str,
+    skip_prompt: bool,
+    profile_name: String,
+) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, log_level),
@@ -79,6 +84,7 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
 
     let default_shared_config = aws_manager::load_config(
         Some(spec.resource.regions[0].clone()),
+        Some(profile_name.clone()),
         Some(Duration::from_secs(30)),
     )
     .await;
@@ -373,8 +379,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let mut regional_resource = r.clone();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_kms_manager = kms::Manager::new(&regional_shared_config);
 
         sleep(Duration::from_secs(1)).await;
@@ -486,8 +496,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let regional_resource = r.clone();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         execute!(
@@ -551,8 +565,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let mut regional_resource = r.clone();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         if regional_resource
@@ -613,8 +631,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let regional_resource = r.clone();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         execute!(
@@ -679,8 +701,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, r) in spec.resource.regional_resources.clone().iter() {
         let mut regional_resource = r.clone();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         if regional_resource.cloudformation_vpc_id.is_none()
@@ -760,8 +786,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
 
         let regional_machine = spec.machine.regional_machines.get(region).unwrap();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         let mut common_asg_params = vec![
@@ -1224,8 +1254,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_machine = spec.machine.regional_machines.get(region).unwrap();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
         if let Some(anchor_asg_logical_ids) =
@@ -1431,8 +1465,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
         let mut regional_resource = r.clone();
         let regional_machine = spec.machine.regional_machines.get(region).unwrap();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         let common_asg_params = region_to_common_asg_params.get(region).unwrap();
@@ -1698,8 +1736,12 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_machine = spec.machine.regional_machines.get(region).unwrap();
 
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
         if let Some(non_anchor_asg_logical_ids) =
@@ -2170,8 +2212,12 @@ cat /tmp/{node_id}.crt
     //
     let mut region_to_ssm_doc_name = HashMap::new();
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         execute!(
@@ -2217,8 +2263,12 @@ cat /tmp/{node_id}.crt
     log::info!("waiting for SSM creation...");
     sleep(Duration::from_secs(10)).await;
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
         execute!(
@@ -2647,6 +2697,7 @@ default-spec --log-level=info --funded-keys={funded_keys} --region={region} --up
 
         let regional_shared_config = aws_manager::load_config(
             Some(spec.resource.regions[0].clone()),
+            Some(profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -67,12 +67,7 @@ pub fn command() -> Command {
 // 50-minute
 const MAX_WAIT_SECONDS: u64 = 50 * 60;
 
-pub async fn execute(
-    log_level: &str,
-    spec_file_path: &str,
-    skip_prompt: bool,
-    profile_name: String,
-) -> io::Result<()> {
+pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, log_level),
@@ -84,7 +79,7 @@ pub async fn execute(
 
     let default_shared_config = aws_manager::load_config(
         Some(spec.resource.regions[0].clone()),
-        Some(profile_name.clone()),
+        Some(spec.profile_name.clone()),
         Some(Duration::from_secs(30)),
     )
     .await;
@@ -381,7 +376,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -498,7 +493,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -567,7 +562,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -633,7 +628,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -703,7 +698,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -788,7 +783,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -1256,7 +1251,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -1467,7 +1462,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -1738,7 +1733,7 @@ pub async fn execute(
 
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -2214,7 +2209,7 @@ cat /tmp/{node_id}.crt
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -2265,7 +2260,7 @@ cat /tmp/{node_id}.crt
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -2697,7 +2692,7 @@ default-spec --log-level=info --funded-keys={funded_keys} --region={region} --up
 
         let regional_shared_config = aws_manager::load_config(
             Some(spec.resource.regions[0].clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -428,6 +428,14 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile-name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 pub async fn execute(opts: avalanche_ops::aws::spec::DefaultSpecOption) -> io::Result<()> {

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -101,6 +101,7 @@ pub async fn execute(
     delete_ebs_volumes: bool,
     delete_elastic_ips: bool,
     skip_prompt: bool,
+    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -112,6 +113,7 @@ pub async fn execute(
 
     let shared_config = aws_manager::load_config(
         Some(spec.resource.regions[0].clone()),
+        Some(profile_name.clone()),
         Some(Duration::from_secs(30)),
     )
     .await;
@@ -169,8 +171,12 @@ pub async fn execute(
 
     if !keep_resources_except_asg_ssm {
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
             let regional_kms_manager = kms::Manager::new(&regional_shared_config);
@@ -241,8 +247,12 @@ pub async fn execute(
 
     if !keep_resources_except_asg_ssm {
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_cloudformation_manager =
                 cloudformation::Manager::new(&regional_shared_config);
@@ -277,8 +287,12 @@ pub async fn execute(
     }
 
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
 
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
@@ -298,8 +312,12 @@ pub async fn execute(
     }
 
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
 
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
@@ -380,8 +398,12 @@ pub async fn execute(
 
     for (region, rr) in spec.resource.regional_resources.clone().iter() {
         let mut regional_resource = rr.clone();
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
 
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
@@ -456,8 +478,12 @@ pub async fn execute(
 
     if !keep_resources_except_asg_ssm {
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_cloudformation_manager =
                 cloudformation::Manager::new(&regional_shared_config);
@@ -503,8 +529,12 @@ pub async fn execute(
 
     if !keep_resources_except_asg_ssm {
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_cloudformation_manager =
                 cloudformation::Manager::new(&regional_shared_config);
@@ -543,8 +573,12 @@ pub async fn execute(
     }
 
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-        let regional_shared_config =
-            aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+        let regional_shared_config = aws_manager::load_config(
+            Some(region.clone()),
+            Some(profile_name.clone()),
+            Some(Duration::from_secs(30)),
+        )
+        .await;
 
         let regional_cloudformation_manager = cloudformation::Manager::new(&regional_shared_config);
 
@@ -601,8 +635,12 @@ pub async fn execute(
 
     if delete_cloudwatch_log_group {
         for (region, _) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_cloudwatch_manager = cloudwatch::Manager::new(&regional_shared_config);
 
@@ -661,8 +699,12 @@ pub async fn execute(
 
     if delete_ebs_volumes {
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 
@@ -757,8 +799,12 @@ pub async fn execute(
 
     if delete_elastic_ips {
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
-            let regional_shared_config =
-                aws_manager::load_config(Some(region.clone()), Some(Duration::from_secs(30))).await;
+            let regional_shared_config = aws_manager::load_config(
+                Some(region.clone()),
+                Some(profile_name.clone()),
+                Some(Duration::from_secs(30)),
+            )
+            .await;
 
             let regional_ec2_manager = ec2::Manager::new(&regional_shared_config);
 

--- a/avalancheup-aws/src/delete/mod.rs
+++ b/avalancheup-aws/src/delete/mod.rs
@@ -91,6 +91,7 @@ pub fn command() -> Command {
         )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     log_level: &str,
     spec_file_path: &str,
@@ -101,7 +102,6 @@ pub async fn execute(
     delete_ebs_volumes: bool,
     delete_elastic_ips: bool,
     skip_prompt: bool,
-    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -113,7 +113,7 @@ pub async fn execute(
 
     let shared_config = aws_manager::load_config(
         Some(spec.resource.regions[0].clone()),
-        Some(profile_name.clone()),
+        Some(spec.profile_name.clone()),
         Some(Duration::from_secs(30)),
     )
     .await;
@@ -173,7 +173,7 @@ pub async fn execute(
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;
@@ -249,7 +249,7 @@ pub async fn execute(
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;
@@ -289,7 +289,7 @@ pub async fn execute(
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -314,7 +314,7 @@ pub async fn execute(
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -400,7 +400,7 @@ pub async fn execute(
         let mut regional_resource = rr.clone();
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -480,7 +480,7 @@ pub async fn execute(
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;
@@ -531,7 +531,7 @@ pub async fn execute(
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;
@@ -575,7 +575,7 @@ pub async fn execute(
     for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
         let regional_shared_config = aws_manager::load_config(
             Some(region.clone()),
-            Some(profile_name.clone()),
+            Some(spec.profile_name.clone()),
             Some(Duration::from_secs(30)),
         )
         .await;
@@ -637,7 +637,7 @@ pub async fn execute(
         for (region, _) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;
@@ -701,7 +701,7 @@ pub async fn execute(
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;
@@ -801,7 +801,7 @@ pub async fn execute(
         for (region, regional_resource) in spec.resource.regional_resources.clone().iter() {
             let regional_shared_config = aws_manager::load_config(
                 Some(region.clone()),
-                Some(profile_name.clone()),
+                Some(spec.profile_name.clone()),
                 Some(Duration::from_secs(30)),
             )
             .await;

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -324,7 +324,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -225,6 +225,10 @@ async fn main() -> io::Result<()> {
                     .get_one::<String>("SPEC_FILE_PATH")
                     .unwrap_or(&String::new())
                     .clone(),
+                profile_name: sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             };
             default_spec::execute(opt)
                 .await
@@ -242,6 +246,10 @@ async fn main() -> io::Result<()> {
                     .unwrap()
                     .clone(),
                 sub_matches.get_flag("SKIP_PROMPT"),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             )
             .await
             .expect("failed to execute 'apply'");
@@ -264,6 +272,10 @@ async fn main() -> io::Result<()> {
                 sub_matches.get_flag("DELETE_EBS_VOLUMES"),
                 sub_matches.get_flag("DELETE_ELASTIC_IPS"),
                 sub_matches.get_flag("SKIP_PROMPT"),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap_or(&String::from("default"))
+                    .clone(),
             )
             .await
             .expect("failed to execute 'delete'");
@@ -410,6 +422,10 @@ async fn main() -> io::Result<()> {
 
                 ssm_docs,
                 target_nodes,
+                profile_name: sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap()
+                    .clone(),
             })
             .await
             .expect("failed to execute 'install-subnet-chain'");

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -246,10 +246,6 @@ async fn main() -> io::Result<()> {
                     .unwrap()
                     .clone(),
                 sub_matches.get_flag("SKIP_PROMPT"),
-                sub_matches
-                    .get_one::<String>("PROFILE_NAME")
-                    .unwrap_or(&String::from("default"))
-                    .clone(),
             )
             .await
             .expect("failed to execute 'apply'");
@@ -272,10 +268,6 @@ async fn main() -> io::Result<()> {
                 sub_matches.get_flag("DELETE_EBS_VOLUMES"),
                 sub_matches.get_flag("DELETE_ELASTIC_IPS"),
                 sub_matches.get_flag("SKIP_PROMPT"),
-                sub_matches
-                    .get_one::<String>("PROFILE_NAME")
-                    .unwrap_or(&String::from("default"))
-                    .clone(),
             )
             .await
             .expect("failed to execute 'delete'");

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -2,7 +2,7 @@
 name = "blizzard-aws"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [[bin]]
 name = "blizzard-aws"
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-types = { version = "0.0.395", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.13", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzard-aws/src/flags.rs
+++ b/blizzard-aws/src/flags.rs
@@ -2,4 +2,5 @@
 #[derive(Debug)]
 pub struct Options {
     pub log_level: String,
+    pub profile_name: String,
 }

--- a/blizzard-aws/src/main.rs
+++ b/blizzard-aws/src/main.rs
@@ -23,6 +23,14 @@ async fn main() {
                 .value_parser(["debug", "info"])
                 .default_value("info"),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
         .get_matches();
 
     println!("{} version: {}", APP_NAME, crate_version!());
@@ -31,6 +39,7 @@ async fn main() {
             .get_one::<String>("LOG_LEVEL")
             .unwrap_or(&String::from("info"))
             .clone(),
+        profile_name: matches.get_one::<String>("PROFILE_NAME").unwrap().clone(),
     };
     command::execute(opts).await.unwrap();
 }

--- a/blizzard-aws/src/main.rs
+++ b/blizzard-aws/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -2,7 +2,7 @@
 name = "blizzardup-aws"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [[bin]]
 name = "blizzardup-aws"
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-types = { version = "0.0.395", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.13", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzardup-aws/src/apply/mod.rs
+++ b/blizzardup-aws/src/apply/mod.rs
@@ -55,7 +55,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/blizzardup-aws/src/apply/mod.rs
+++ b/blizzardup-aws/src/apply/mod.rs
@@ -53,12 +53,25 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(0),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 // 50-minute
 const MAX_WAIT_SECONDS: u64 = 50 * 60;
 
-pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -> io::Result<()> {
+pub async fn execute(
+    log_level: &str,
+    spec_file_path: &str,
+    skip_prompt: bool,
+    profile_name: String,
+) -> io::Result<()> {
     #[derive(RustEmbed)]
     #[folder = "cfn-templates/"]
     #[prefix = "cfn-templates/"]
@@ -75,6 +88,7 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
     let mut resources = spec.resources.clone().unwrap();
     let shared_config = aws_manager::load_config(
         Some(resources.region.clone()),
+        Some(profile_name),
         Some(Duration::from_secs(30)),
     )
     .await;

--- a/blizzardup-aws/src/delete/mod.rs
+++ b/blizzardup-aws/src/delete/mod.rs
@@ -68,7 +68,7 @@ pub fn command() -> Command {
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/blizzardup-aws/src/delete/mod.rs
+++ b/blizzardup-aws/src/delete/mod.rs
@@ -66,6 +66,14 @@ pub fn command() -> Command {
                 .required(false)
                 .num_args(0),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
 }
 
 // 50-minute
@@ -78,6 +86,7 @@ pub async fn execute(
     delete_s3_objects: bool,
     delete_s3_bucket: bool,
     skip_prompt: bool,
+    profile_name: String,
 ) -> io::Result<()> {
     // ref. <https://github.com/env-logger-rs/env_logger/issues/47>
     env_logger::init_from_env(
@@ -89,6 +98,7 @@ pub async fn execute(
 
     let shared_config = aws_manager::load_config(
         Some(resources.region.clone()),
+        Some(profile_name),
         Some(Duration::from_secs(30)),
     )
     .await;

--- a/blizzardup-aws/src/main.rs
+++ b/blizzardup-aws/src/main.rs
@@ -106,6 +106,10 @@ async fn main() {
                     .unwrap()
                     .clone(),
                 sub_matches.get_flag("SKIP_PROMPT"),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap()
+                    .clone(),
             )
             .await
             .expect("failed to execute 'apply'");
@@ -125,6 +129,10 @@ async fn main() {
                 sub_matches.get_flag("DELETE_S3_OBJECTS"),
                 sub_matches.get_flag("DELETE_S3_BUCKET"),
                 sub_matches.get_flag("SKIP_PROMPT"),
+                sub_matches
+                    .get_one::<String>("PROFILE_NAME")
+                    .unwrap()
+                    .clone(),
             )
             .await
             .expect("failed to execute 'delete'");

--- a/blizzardup-aws/src/query/mod.rs
+++ b/blizzardup-aws/src/query/mod.rs
@@ -56,6 +56,7 @@ pub async fn execute(log_level: &str, spec_file_path: &str) -> io::Result<()> {
     let mut prev: HashMap<String, HashMap<String, f64>> = HashMap::new();
 
     // TODO: implement better math...
+    #[allow(clippy::never_loop)]
     loop {
         for rpc_ep in spec.blizzard_spec.chain_rpc_urls.iter() {
             let (scheme, host, port, _, _) =

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -2,11 +2,11 @@
 name = "staking-key-cert-s3-downloader"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [dependencies]
 avalanche-types = { version = "0.0.395", features = [] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.13", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.18"

--- a/staking-key-cert-s3-downloader/src/command.rs
+++ b/staking-key-cert-s3-downloader/src/command.rs
@@ -20,13 +20,20 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, opts.log_level),
     );
 
-    let s3_shared_config =
-        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
+    let s3_shared_config = aws_manager::load_config(
+        Some(opts.s3_region.clone()),
+        Some(opts.profile_name.clone()),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let s3_manager = s3::Manager::new(&s3_shared_config);
 
-    let kms_shared_config =
-        aws_manager::load_config(Some(opts.kms_region.clone()), Some(Duration::from_secs(30)))
-            .await;
+    let kms_shared_config = aws_manager::load_config(
+        Some(opts.kms_region.clone()),
+        Some(opts.profile_name.clone()),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let kms_manager = kms::Manager::new(&kms_shared_config);
 
     let envelope_manager = envelope::Manager::new(

--- a/staking-key-cert-s3-downloader/src/flags.rs
+++ b/staking-key-cert-s3-downloader/src/flags.rs
@@ -11,4 +11,5 @@ pub struct Options {
     pub aad_tag: String,
     pub tls_key_path: String,
     pub tls_cert_path: String,
+    pub profile_name: String,
 }

--- a/staking-key-cert-s3-downloader/src/main.rs
+++ b/staking-key-cert-s3-downloader/src/main.rs
@@ -101,6 +101,14 @@ staking-key-cert-s3-downloader \
                 .required(true)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
         .get_matches();
 
     let opts = flags::Options {
@@ -120,6 +128,7 @@ staking-key-cert-s3-downloader \
         aad_tag: matches.get_one::<String>("AAD_TAG").unwrap().clone(),
         tls_key_path: matches.get_one::<String>("TLS_KEY_PATH").unwrap().clone(),
         tls_cert_path: matches.get_one::<String>("TLS_CERT_PATH").unwrap().clone(),
+        profile_name: matches.get_one::<String>("PROFILE_NAME").unwrap().clone(),
     };
     command::execute(opts).await.unwrap();
 }

--- a/staking-key-cert-s3-downloader/src/main.rs
+++ b/staking-key-cert-s3-downloader/src/main.rs
@@ -103,7 +103,7 @@ staking-key-cert-s3-downloader \
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -2,10 +2,10 @@
 name = "staking-signer-key-s3-downloader"
 version = "0.8.5" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [dependencies]
-aws-manager = { version = "0.28.13", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.15", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.18"

--- a/staking-signer-key-s3-downloader/src/command.rs
+++ b/staking-signer-key-s3-downloader/src/command.rs
@@ -19,13 +19,20 @@ pub async fn execute(opts: flags::Options) -> io::Result<()> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, opts.log_level),
     );
 
-    let s3_shared_config =
-        aws_manager::load_config(Some(opts.s3_region.clone()), Some(Duration::from_secs(30))).await;
+    let s3_shared_config = aws_manager::load_config(
+        Some(opts.s3_region.clone()),
+        Some(opts.profile_name.clone()),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let s3_manager = s3::Manager::new(&s3_shared_config);
 
-    let kms_shared_config =
-        aws_manager::load_config(Some(opts.kms_region.clone()), Some(Duration::from_secs(30)))
-            .await;
+    let kms_shared_config = aws_manager::load_config(
+        Some(opts.kms_region.clone()),
+        Some(opts.profile_name.clone()),
+        Some(Duration::from_secs(30)),
+    )
+    .await;
     let kms_manager = kms::Manager::new(&kms_shared_config);
 
     let envelope_manager = envelope::Manager::new(

--- a/staking-signer-key-s3-downloader/src/flags.rs
+++ b/staking-signer-key-s3-downloader/src/flags.rs
@@ -9,4 +9,5 @@ pub struct Options {
     pub kms_key_id: String,
     pub aad_tag: String,
     pub key_path: String,
+    pub profile_name: String,
 }

--- a/staking-signer-key-s3-downloader/src/main.rs
+++ b/staking-signer-key-s3-downloader/src/main.rs
@@ -85,6 +85,14 @@ staking-signer-key-s3-downloader \
                 .required(true)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("PROFILE_NAME")
+                .long("profile_name")
+                .help("Sets the AWS credential profile name for API calls/endpoints")
+                .required(false)
+                .default_value("default")
+                .num_args(1),
+        )
         .get_matches();
 
     let opts = flags::Options {
@@ -99,6 +107,7 @@ staking-signer-key-s3-downloader \
         kms_key_id: matches.get_one::<String>("KMS_KEY_ID").unwrap().clone(),
         aad_tag: matches.get_one::<String>("AAD_TAG").unwrap().clone(),
         key_path: matches.get_one::<String>("KEY_PATH").unwrap().clone(),
+        profile_name: matches.get_one::<String>("PROFILE_NAME").unwrap().clone(),
     };
     command::execute(opts).await.unwrap();
 }

--- a/staking-signer-key-s3-downloader/src/main.rs
+++ b/staking-signer-key-s3-downloader/src/main.rs
@@ -87,7 +87,7 @@ staking-signer-key-s3-downloader \
         )
         .arg(
             Arg::new("PROFILE_NAME")
-                .long("profile_name")
+                .long("profile-name")
                 .help("Sets the AWS credential profile name for API calls/endpoints")
                 .required(false)
                 .default_value("default")


### PR DESCRIPTION
Updates the aws-manager dependency across all crates.

Note: the minimum Rust version is now 1.70.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
