### PR TITLE
Bump dependencies version in avalanche-ops

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-avalanche-types = { version = "0.0.395", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.15", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.398", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.28.42", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.26.1"
 dialoguer = "0.10.4"
 env_logger = "0.10.0"
-ethers-signers = "2.0.6"
+ethers-signers = "2.0.7"
 id-manager = "0.0.3"
 log = "0.4.18"
 primitive-types = "0.12.1" # https://crates.io/crates/primitive-types

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-avalanche-types = { version = "0.0.395", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.15", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.398", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.28.42", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.10"
 dir-manager = "0.0.1"
 env_logger = "0.10.0"

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/main.rs"
 avalanche-installer = "0.0.76" # https://crates.io/crates/avalanche-installer
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.107" # https://crates.io/crates/avalanche-telemetry-cloudwatch-installer
-avalanche-types = { version = "0.0.395", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.398", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.96" # https://crates.io/crates/aws-ip-provisioner-installer
-aws-manager = { version = "0.28.15", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.42", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-ops = { path = "../avalanche-ops" }
-avalanche-types = { version = "0.0.395", features = ["avalanchego", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.398", features = ["avalanchego", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-dev-machine = "0.0.17"
-aws-manager = { version = "0.28.15", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.42", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -9,15 +9,15 @@ name = "blizzard-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.395", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.15", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.398", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.28.42", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 blizzardup-aws = { path = "../blizzardup-aws" }
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
-ethers-signers = { version = "=2.0.6", optional = false }
+ethers-signers = { version = "=2.0.7", optional = false }
 log = "0.4.18"
 primitive-types = { version = "0.12.1", optional = false } # https://crates.io/crates/primitive-types
 random-manager = "0.0.5"

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -9,8 +9,8 @@ name = "blizzardup-aws"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.395", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.15", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.398", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.28.42", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.28.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/cdk/avalancheup-aws/package-lock.json
+++ b/cdk/avalancheup-aws/package-lock.json
@@ -1082,8 +1082,8 @@
       "dev": true
     },
     "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.7.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
@@ -1558,7 +1558,7 @@
       "dependencies": {
         "caniuse-lite": "^1.0.30001370",
         "electron-to-chromium": "^1.4.202",
-        "node-releases": "^2.0.6",
+        "node-releases": "^2.0.7",
         "update-browserslist-db": "^1.0.5"
       },
       "bin": {
@@ -2062,8 +2062,8 @@
       "dev": true
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.7.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
@@ -3393,8 +3393,8 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.7.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
@@ -3456,7 +3456,7 @@
       "dev": true,
       "dependencies": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
+        "fast-levenshtein": "~2.0.7",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
@@ -5344,8 +5344,8 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.7.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
@@ -5675,7 +5675,7 @@
       "requires": {
         "caniuse-lite": "^1.0.30001370",
         "electron-to-chromium": "^1.4.202",
-        "node-releases": "^2.0.6",
+        "node-releases": "^2.0.7",
         "update-browserslist-db": "^1.0.5"
       }
     },
@@ -6052,8 +6052,8 @@
       "dev": true
     },
     "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.7.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
@@ -7077,8 +7077,8 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.7.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
@@ -7128,7 +7128,7 @@
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
+        "fast-levenshtein": "~2.0.7",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",

--- a/devnet-faucet/Cargo.toml
+++ b/devnet-faucet/Cargo.toml
@@ -9,14 +9,14 @@ name = "devnet-faucet"
 path = "src/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.395", features = ["evm", "jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.398", features = ["evm", "jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
 bytes = "1.4.0"
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
-ethers = { version = "=2.0.6" }
-ethers-core = { version = "=2.0.6", features = ["eip712"] }
-ethers-providers = { version = "=2.0.6" }
-ethers-signers = { version = "=2.0.6" }
+ethers = { version = "=2.0.7" }
+ethers-core = { version = "=2.0.7", features = ["eip712"] }
+ethers-providers = { version = "=2.0.7" }
+ethers-signers = { version = "=2.0.7" }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 governor = "0.5.1"
 log = "0.4.18"

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-avalanche-types = { version = "0.0.395", features = [] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.28.15", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+avalanche-types = { version = "0.0.398", features = [] } # https://crates.io/crates/avalanche-types
+aws-manager = { version = "0.28.42", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.18"

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-aws-manager = { version = "0.28.15", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.28.42", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.18"


### PR DESCRIPTION
Updated dependencies list: avalanche-types, aws-manager, and ethers-core