### PR TITLE
avalancheup-aws: support --image-ids flag

### DIFF
--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -379,6 +379,7 @@ pub struct DefaultSpecOption {
     pub instance_mode: String,
     pub instance_size: String,
     pub instance_types: HashMap<String, Vec<String>>,
+    pub image_ids: HashMap<String, String>,
     pub volume_size_in_gb: u32,
 
     pub ip_mode: String,
@@ -647,6 +648,7 @@ impl Spec {
                 anchor_nodes: None,
                 non_anchor_nodes: 0,
                 instance_types: region_to_instance_types.get(reg).unwrap().clone(),
+                image_id: opts.image_ids.get(reg).unwrap_or(&String::new()).clone(),
             };
 
             // last iteration, but still remaining... use them up
@@ -1267,6 +1269,7 @@ machine:
 
   regional_machines:
     us-west-2:
+      image_id: ami-123
       non_anchor_nodes: 1
       instance_types:
       - m5.large
@@ -1387,6 +1390,7 @@ coreth_chain_config:
                 String::from("r5.large"),
                 String::from("t3.large"),
             ],
+            image_id: String::from("ami-123"),
         },
     );
 
@@ -1842,6 +1846,8 @@ pub struct RegionalMachine {
     pub non_anchor_nodes: u32,
     #[serde(default)]
     pub instance_types: Vec<String>,
+    #[serde(default)]
+    pub image_id: String,
 }
 
 /// Represents artifacts for installation, to be shared with

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -842,19 +842,23 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
             build_param("ArchType", &spec.machine.arch_type),
             build_param("OsType", &spec.machine.os_type),
             build_param(
+                "AvalanchedAwsArgs",
+                &format!("agent {}", spec.avalanched_config.to_flags()),
+            ),
+            build_param("ProvisionerInitialWaitRandomSeconds", "15"),
+        ];
+        if !regional_machine.image_id.is_empty() {
+            common_asg_params.push(build_param("ImageId", &regional_machine.image_id));
+        } else {
+            common_asg_params.push(build_param(
                 "ImageIdSsmParameter",
                 &ec2::default_image_id_ssm_parameter(
                     &spec.machine.arch_type,
                     &spec.machine.os_type,
                 )
                 .unwrap(),
-            ),
-            build_param(
-                "AvalanchedAwsArgs",
-                &format!("agent {}", spec.avalanched_config.to_flags()),
-            ),
-            build_param("ProvisionerInitialWaitRandomSeconds", "15"),
-        ];
+            ));
+        }
 
         // just copy the regional machine params, and later overwrite if 'create-dev-machine' is true
         let mut common_dev_machine_params = BTreeMap::new();

--- a/avalancheup-aws/src/default_spec/mod.rs
+++ b/avalancheup-aws/src/default_spec/mod.rs
@@ -202,6 +202,14 @@ pub fn command() -> Command {
                 .num_args(1),
         )
         .arg(
+            Arg::new("IMAGE_IDS")
+                .long("image-ids")
+                .help("Sets the hash map from a region to the EC2 image ID to overwrite SSM parameter")
+                .required(false)
+                .value_parser(HashMapStringToStringParser {})
+                .num_args(1),
+        )
+        .arg(
             Arg::new("IP_MODE")
                 .long("ip-mode")
                 .help("Sets IP mode to provision EC2 elastic IPs for all nodes")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -51,6 +51,10 @@ async fn main() -> io::Result<()> {
                 .get_one::<HashMap<String, Vec<String>>>("INSTANCE_TYPES")
                 .unwrap_or(&HashMap::new())
                 .clone();
+            let image_ids: HashMap<String, String> = sub_matches
+                .get_one::<HashMap<String, String>>("IMAGE_IDS")
+                .unwrap_or(&HashMap::new())
+                .clone();
 
             let nlb_acm_certificate_arns: HashMap<String, String> = sub_matches
                 .get_one::<HashMap<String, String>>("NLB_ACM_CERTIFICATE_ARNS")
@@ -125,6 +129,7 @@ async fn main() -> io::Result<()> {
                     .unwrap_or(&String::from("large"))
                     .clone(),
                 instance_types,
+                image_ids,
 
                 volume_size_in_gb: *sub_matches
                     .get_one::<u32>("VOLUME_SIZE_IN_GB")


### PR DESCRIPTION
For https://github.com/ava-labs/avalanche-ops/issues/382

```
--image-ids {"us-west-2":"ami-0b311b426c64dd828"}
```
