### PR TITLE
feat: Add DevMachineIngress to VPC

### DIFF
--- a/avalanche-ops/src/aws/cfn-templates/vpc.yaml
+++ b/avalanche-ops/src/aws/cfn-templates/vpc.yaml
@@ -313,6 +313,16 @@ Resources:
       FromPort: !Ref StakingPort
       ToPort: !Ref StakingPort
       CidrIp: !Ref StakingPortIngressIpv4Range
+  
+  # ingress from dev machine(s) to the node network
+  DevMachineIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: "-1"
+      FromPort: "-1"
+      ToPort: "-1"
+      SourceSecurityGroupId: !Ref DevMachineSecurityGroup
 
   # allow all outbound traffic
   Egress:


### PR DESCRIPTION
Adds a new DevMachineIngress to allow inbound traffic 
from any machine in the dev machine sg to the node network. 

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
