### PR TITLE
fix: Add profile_name to install-subnet-chain sample command

### DIFF
--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -2575,6 +2575,7 @@ cat /tmp/{node_id}.crt
         Print(format!(
             "{exec_path} install-subnet-chain \\
 --log-level info \\
+--profile-name <REPLACE_ME> \\
 --s3-region {s3_region} \\
 --s3-bucket {s3_bucket} \\
 --s3-key-prefix {id}/install-subnet-chain \\
@@ -2584,7 +2585,7 @@ cat /tmp/{node_id}.crt
 --subnet-validate-period-in-days 14 \\
 --subnet-config-local-path /tmp/subnet-config.json \\
 --subnet-config-remote-dir {subnet_config_remote_dir} \\
---vm-binary-local-path REPLACE_ME \\
+--vm-binary-local-path <REPLACE_ME> \\
 --vm-binary-remote-dir {vm_plugin_remote_dir} \\
 --chain-name subnetevm \\
 --chain-genesis-path /tmp/subnet-evm-genesis.json \\

--- a/avalancheup-aws/src/install_subnet_chain/mod.rs
+++ b/avalancheup-aws/src/install_subnet_chain/mod.rs
@@ -959,7 +959,7 @@ pub async fn execute(opts: Flags) -> io::Result<()> {
         );
 
         let avalanched_alias_args = format!(
-            "alias-chain --log-level info --chain_id {chain_id} --chain_alias {alias}",
+            "alias-chain --log-level info --chain-id {chain_id} --chain-name {alias}",
             chain_id = blockchain_id,
             alias = opts.chain_name.clone(),
         );


### PR DESCRIPTION
* Adds profile_name to the helptext

* Fixes alias chain SSM command


Signed-off-by: Dan Sover <dan.sover@avalabs.org>
