### PR TITLE
fix: Bump aws-manager to v0.30.2

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.70"
 
 [dependencies]
 avalanche-types = { version = "0.0.404", features = ["jsonrpc_client", "wallet", "wallet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.30.1", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["kms", "sts"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.4.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 crossterm = "0.27.0"
 dialoguer = "0.10.4"

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 avalanche-types = { version = "0.0.404", features = ["avalanchego"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.30.1", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["ec2", "sts"] } # https://github.com/gyuho/aws-manager/tags
 compress-manager = "0.0.10"
 dir-manager = "0.0.1"
 env_logger = "0.10.0"

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -14,7 +14,7 @@ avalanche-ops = { path = "../avalanche-ops" }
 avalanche-telemetry-cloudwatch-installer = "0.0.107" # https://crates.io/crates/avalanche-telemetry-cloudwatch-installer
 avalanche-types = { version = "0.0.404", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
 aws-ip-provisioner-installer = "0.0.96" # https://crates.io/crates/aws-ip-provisioner-installer
-aws-manager = { version = "0.30.1", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["autoscaling", "cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 avalanche-ops = { path = "../avalanche-ops" }
 avalanche-types = { version = "0.0.404", features = ["avalanchego", "jsonrpc_client", "wallet", "subnet", "subnet_evm", "kms_aws"] } # https://crates.io/crates/avalanche-types
 aws-dev-machine = "0.0.17"
-aws-manager = { version = "0.30.1", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["cloudformation", "cloudwatch", "ec2", "s3", "ssm", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-types = { version = "0.0.404", features = ["jsonrpc_client", "wallet", "wallet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.30.1", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["cloudwatch", "ec2", "s3"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudwatch = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 avalanche-types = { version = "0.0.404", features = ["avalanchego", "jsonrpc_client", "subnet_evm"] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.30.1", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["cloudformation", "cloudwatch", "ec2", "s3", "sts"] } # https://github.com/gyuho/aws-manager/tags
 aws-sdk-cloudformation = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-ec2 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases
 aws-sdk-s3 = "0.30.0" # https://github.com/awslabs/aws-sdk-rust/releases

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.70"
 
 [dependencies]
 avalanche-types = { version = "0.0.404", features = [] } # https://crates.io/crates/avalanche-types
-aws-manager = { version = "0.30.1", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.4.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.20"

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-aws-manager = { version = "0.30.1", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
+aws-manager = { version = "0.30.2", features = ["kms", "s3"] } # https://github.com/gyuho/aws-manager/tags
 clap = { version = "4.4.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 env_logger = "0.10.0"
 log = "0.4.20"


### PR DESCRIPTION
Includes the required s3 upload fix.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
