### PR TITLE
feat: Add api node type

### DIFF
--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -394,6 +394,7 @@ pub struct DefaultSpecOption {
     pub os_type: String,
     pub anchor_nodes: u32,
     pub non_anchor_nodes: u32,
+    pub api_nodes: u32,
 
     pub key_files_dir: String,
     pub keys_to_generate: usize,
@@ -960,6 +961,7 @@ impl Spec {
         let machine = Machine {
             total_anchor_nodes,
             total_non_anchor_nodes,
+            total_api_nodes: opts.api_nodes,
 
             arch_type: opts.arch_type,
             os_type: opts.os_type,
@@ -998,6 +1000,15 @@ impl Spec {
                     format!(
                         "chain-genesis-file {} specified but does not exists",
                         opts.chain_genesis_file
+                    ),
+                ));
+            }
+            if opts.api_nodes > total_non_anchor_nodes {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!(
+                        "api-nodes={} must be less than or equal to total-non-anchor-nodes={}",
+                        opts.api_nodes, total_non_anchor_nodes
                     ),
                 ));
             }
@@ -1575,6 +1586,7 @@ coreth_chain_config:
         machine: Machine {
             total_anchor_nodes: None,
             total_non_anchor_nodes: 1,
+            total_api_nodes: 0,
 
             arch_type: "amd64".to_string(),
             os_type: "ubuntu20.04".to_string(),
@@ -1698,6 +1710,7 @@ pub struct Node {
 }
 
 impl Node {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         region: &str,
         kind: node::Kind,
@@ -1952,7 +1965,9 @@ pub struct Machine {
     pub total_anchor_nodes: Option<u32>,
     #[serde(default)]
     pub total_non_anchor_nodes: u32,
-
+    /// API Nodes relay transactions but are not validators.
+    #[serde(default)]
+    pub total_api_nodes: u32,
     #[serde(default)]
     pub arch_type: String,
     #[serde(default)]

--- a/avalanche-ops/src/aws/spec.rs
+++ b/avalanche-ops/src/aws/spec.rs
@@ -175,7 +175,7 @@ pub struct Resource {
     #[serde(default)]
     pub user_defined_ipv4_cidr: String,
 
-    /// Only populate as many as we need to fill up anchor/non-anchor nodes.
+    /// Only populate as many as we need to fill up anchor/non-anchor/api nodes.
     /// e.g., "regions" may have 5 but we may only need 2 regions for 3 node cluster.
     #[serde(default)]
     pub regional_resources: BTreeMap<String, RegionalResource>,
@@ -293,7 +293,14 @@ pub struct RegionalResource {
     /// READ ONLY -- DO NOT SET.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloudformation_asg_non_anchor_nodes_logical_ids: Option<Vec<String>>,
-
+    /// Only updated after creation.
+    /// READ ONLY -- DO NOT SET.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudformation_asg_api_nodes: Option<Vec<String>>,
+    /// Only updated after creation.
+    /// READ ONLY -- DO NOT SET.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudformation_asg_api_nodes_logical_ids: Option<Vec<String>>,
     /// Only updated after creation.
     /// READ ONLY -- DO NOT SET.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -362,6 +369,9 @@ impl Default for RegionalResource {
             cloudformation_asg_non_anchor_nodes: None,
             cloudformation_asg_non_anchor_nodes_logical_ids: None,
 
+            cloudformation_asg_api_nodes: None,
+            cloudformation_asg_api_nodes_logical_ids: None,
+
             cloudformation_asg_nlb_arn: None,
             cloudformation_asg_nlb_target_group_arn: None,
             cloudformation_asg_nlb_dns_name: None,
@@ -394,6 +404,7 @@ pub struct DefaultSpecOption {
     pub os_type: String,
     pub anchor_nodes: u32,
     pub non_anchor_nodes: u32,
+    pub api_nodes: u32,
 
     pub key_files_dir: String,
     pub keys_to_generate: usize,
@@ -556,7 +567,7 @@ impl Spec {
             }
         };
 
-        let (total_anchor_nodes, total_non_anchor_nodes) =
+        let (total_anchor_nodes, total_non_anchor_nodes, total_api_nodes) =
             match constants::NETWORK_ID_TO_NETWORK_NAME.get(&network_id) {
                 // non-custom network only single node to utilize single AZ
                 Some(_) => (
@@ -565,6 +576,11 @@ impl Spec {
                         opts.non_anchor_nodes
                     } else {
                         DEFAULT_MACHINE_NON_ANCHOR_NODES
+                    },
+                    if opts.api_nodes > 0 {
+                        opts.api_nodes
+                    } else {
+                        DEFAULT_MACHINE_API_NODES // 0
                     },
                 ),
 
@@ -580,8 +596,13 @@ impl Spec {
                     } else {
                         DEFAULT_MACHINE_NON_ANCHOR_NODES
                     };
+                    let api_nodes = if opts.api_nodes > 0 {
+                        opts.api_nodes
+                    } else {
+                        DEFAULT_MACHINE_API_NODES
+                    };
 
-                    (Some(anchor_nodes), non_anchor_nodes)
+                    (Some(anchor_nodes), non_anchor_nodes, api_nodes)
                 }
             };
 
@@ -678,6 +699,7 @@ impl Spec {
         // only iterate until we used up all total* nodes
         let mut current_anchor_nodes = 0_u32;
         let mut current_non_anchor_nodes = 0_u32;
+        let mut current_api_nodes = 0_u32;
 
         let mut regional_resources = BTreeMap::new();
         let mut regional_machines = BTreeMap::new();
@@ -686,6 +708,7 @@ impl Spec {
             let mut regional_machine = RegionalMachine {
                 anchor_nodes: None,
                 non_anchor_nodes: 0,
+                api_nodes: 0,
                 instance_types: region_to_instance_types.get(reg).unwrap().clone(),
                 image_id: opts.image_ids.get(reg).unwrap_or(&String::new()).clone(),
             };
@@ -727,7 +750,24 @@ impl Spec {
                 }
             }
 
-            if regional_machine.anchor_nodes.is_none() && regional_machine.non_anchor_nodes == 0 {
+            if total_api_nodes > current_api_nodes {
+                let mut per_region = total_api_nodes / regions.len() as u32;
+                if per_region == 0 {
+                    per_region = 1;
+                }
+                if i == regions.len() - 1 {
+                    regional_machine.api_nodes = total_api_nodes - current_api_nodes;
+                    current_api_nodes = total_api_nodes;
+                } else {
+                    regional_machine.api_nodes = per_region;
+                    current_api_nodes += per_region;
+                }
+            }
+
+            if regional_machine.anchor_nodes.is_none()
+                && regional_machine.non_anchor_nodes == 0
+                && regional_machine.api_nodes == 0
+            {
                 log::info!("no more node to allocate in region '{reg}' -- skipping");
                 continue;
             }
@@ -960,6 +1000,7 @@ impl Spec {
         let machine = Machine {
             total_anchor_nodes,
             total_non_anchor_nodes,
+            total_api_nodes,
 
             arch_type: opts.arch_type,
             os_type: opts.os_type,
@@ -1166,6 +1207,15 @@ impl Spec {
                 format!(
                     "'machine.non_anchor_nodes' {} >maximum {}",
                     self.machine.total_non_anchor_nodes, MAX_MACHINE_NON_ANCHOR_NODES
+                ),
+            ));
+        }
+        if self.machine.total_api_nodes > MAX_MACHINE_API_NODES {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "'machine.api_nodes' {} >maximum {}",
+                    self.machine.total_api_nodes, MAX_MACHINE_API_NODES
                 ),
             ));
         }
@@ -1548,6 +1598,7 @@ coreth_chain_config:
         RegionalMachine {
             anchor_nodes: None,
             non_anchor_nodes: 1,
+            api_nodes: 0,
             instance_types: vec![
                 String::from("m5.large"),
                 String::from("c5.large"),
@@ -1575,6 +1626,7 @@ coreth_chain_config:
         machine: Machine {
             total_anchor_nodes: None,
             total_non_anchor_nodes: 1,
+            total_api_nodes: 0,
 
             arch_type: "amd64".to_string(),
             os_type: "ubuntu20.04".to_string(),
@@ -1886,6 +1938,10 @@ pub const MIN_MACHINE_NON_ANCHOR_NODES: u32 = 1;
 pub const MAX_MACHINE_NON_ANCHOR_NODES: u32 = 500;
 pub const DEFAULT_MACHINE_NON_ANCHOR_NODES: u32 = 1;
 
+pub const MIN_MACHINE_API_NODES: u32 = 0;
+pub const MAX_MACHINE_API_NODES: u32 = 100;
+pub const DEFAULT_MACHINE_API_NODES: u32 = 0;
+
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Endpoints {
@@ -1952,6 +2008,9 @@ pub struct Machine {
     pub total_anchor_nodes: Option<u32>,
     #[serde(default)]
     pub total_non_anchor_nodes: u32,
+    #[serde(default)]
+    /// API Nodes relay transactions but are not validators.
+    pub total_api_nodes: u32,
 
     #[serde(default)]
     pub arch_type: String,
@@ -2012,6 +2071,8 @@ pub struct RegionalMachine {
     pub anchor_nodes: Option<u32>,
     #[serde(default)]
     pub non_anchor_nodes: u32,
+    #[serde(default)]
+    pub api_nodes: u32,
     #[serde(default)]
     pub instance_types: Vec<String>,
     #[serde(default)]

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -159,14 +159,6 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
         }
         regional_resource.cloudformation_asg_non_anchor_nodes = Some(asg_names);
 
-        let api_nodes = regional_machine.api_nodes;
-        let mut api_asg_names = Vec::new();
-        for i in 0..api_nodes {
-            let asg_name = format!("{}-api-{}-{:02}", spec.id, spec.machine.arch_type, i + 1);
-            api_asg_names.push(asg_name);
-        }
-        regional_resource.cloudformation_asg_api_nodes = Some(api_asg_names);
-
         // just create these no matter what for simplification
         regional_resource.cloudformation_ssm_install_subnet_chain = Some(
             avalanche_ops::aws::spec::StackName::SsmInstallSubnetChain(spec.id.clone()).encode(),

--- a/avalancheup-aws/src/apply/mod.rs
+++ b/avalancheup-aws/src/apply/mod.rs
@@ -159,6 +159,14 @@ pub async fn execute(log_level: &str, spec_file_path: &str, skip_prompt: bool) -
         }
         regional_resource.cloudformation_asg_non_anchor_nodes = Some(asg_names);
 
+        let api_nodes = regional_machine.api_nodes;
+        let mut api_asg_names = Vec::new();
+        for i in 0..api_nodes {
+            let asg_name = format!("{}-api-{}-{:02}", spec.id, spec.machine.arch_type, i + 1);
+            api_asg_names.push(asg_name);
+        }
+        regional_resource.cloudformation_asg_api_nodes = Some(api_asg_names);
+
         // just create these no matter what for simplification
         regional_resource.cloudformation_ssm_install_subnet_chain = Some(
             avalanche_ops::aws::spec::StackName::SsmInstallSubnetChain(spec.id.clone()).encode(),

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -95,6 +95,7 @@ async fn main() -> io::Result<()> {
 
                 anchor_nodes: *sub_matches.get_one::<u32>("ANCHOR_NODES").unwrap_or(&0),
                 non_anchor_nodes: *sub_matches.get_one::<u32>("NON_ANCHOR_NODES").unwrap_or(&0),
+                api_nodes: *sub_matches.get_one::<u32>("API_NODES").unwrap_or(&0),
 
                 key_files_dir: sub_matches
                     .get_one::<String>("KEY_FILES_DIR")

--- a/avalancheup-aws/src/main.rs
+++ b/avalancheup-aws/src/main.rs
@@ -95,7 +95,6 @@ async fn main() -> io::Result<()> {
 
                 anchor_nodes: *sub_matches.get_one::<u32>("ANCHOR_NODES").unwrap_or(&0),
                 non_anchor_nodes: *sub_matches.get_one::<u32>("NON_ANCHOR_NODES").unwrap_or(&0),
-                api_nodes: *sub_matches.get_one::<u32>("API_NODES").unwrap_or(&0),
 
                 key_files_dir: sub_matches
                     .get_one::<String>("KEY_FILES_DIR")


### PR DESCRIPTION
Adds a new API node type, that runs in the subnet but is not a validator. 

Part of HyperSDK load testing. Adding API nodes would create a more realistic testing environment.

Closes #458

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
