### PR TITLE
*: Bump to v1.0.0

### DIFF
--- a/avalanche-kms/Cargo.toml
+++ b/avalanche-kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-kms"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 

--- a/avalanche-ops/Cargo.toml
+++ b/avalanche-ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-ops"
-version = "1.0.0-alpha.4" # https://crates.io/crates/avalanche-ops
+version = "1.0.0" # https://crates.io/crates/avalanche-ops
 edition = "2021"
 rust-version = "1.70"
 publish = true

--- a/avalanched-aws/Cargo.toml
+++ b/avalanched-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanched-aws"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 

--- a/avalancheup-aws/Cargo.toml
+++ b/avalancheup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalancheup-aws"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 

--- a/blizzard-aws/Cargo.toml
+++ b/blizzard-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzard-aws"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 

--- a/blizzardup-aws/Cargo.toml
+++ b/blizzardup-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizzardup-aws"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 

--- a/devnet-faucet/Cargo.toml
+++ b/devnet-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devnet-faucet"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/staking-key-cert-s3-downloader/Cargo.toml
+++ b/staking-key-cert-s3-downloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking-key-cert-s3-downloader"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 

--- a/staking-signer-key-s3-downloader/Cargo.toml
+++ b/staking-signer-key-s3-downloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking-signer-key-s3-downloader"
-version = "1.0.0-alpha.4" # https://github.com/ava-labs/avalanche-ops/releases
+version = "1.0.0" # https://github.com/ava-labs/avalanche-ops/releases
 edition = "2021"
 rust-version = "1.70"
 


### PR DESCRIPTION
Now that the devnet functionality is complete, avalanche-ops is considered v1.0.0.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
